### PR TITLE
Render tab components in consistent order in DOM

### DIFF
--- a/src/view/Layout.js
+++ b/src/view/Layout.js
@@ -89,19 +89,21 @@ class Layout extends React.Component {
         this.model._layout(this.rect);
         this.renderChildren(this.model.getRoot(), tabSetComponents, tabComponents, splitterComponents);
 
-        const nextToIds = [];
+        const nextTopIds = [];
+        const nextTopIdsMap = {};
         // Keep any previous tabs in the same DOM order as before, removing any that have been deleted
         this.tabIds.forEach(t => {
-            if (Object.keys(tabComponents).find(tt => t === tt)) {
+            if (tabComponents[t]) {
                 nextTopIds.push(t);
+                nextTopIdsMap[t] = t;
             }
         });
         this.tabIds = nextTopIds;
 
         // Add tabs that have been added to the DOM
         Object.keys(tabComponents).forEach(t => {
-            if (!this.tabIds.find(tt => t === tt)) {
-              this.tabIds.push(t);
+            if (!nextTopIdsMap[t]) {
+                this.tabIds.push(t);
             }
         });
 

--- a/src/view/Layout.js
+++ b/src/view/Layout.js
@@ -27,6 +27,7 @@ class Layout extends React.Component {
         this.rect = new Rect(0, 0, 0, 0);
         this.model.setListener(this.onModelChange.bind(this));
         this.updateRect = this.updateRect.bind(this);
+        this.tabIds = [];
     }
 
     onModelChange() {
@@ -81,24 +82,52 @@ class Layout extends React.Component {
     }
 
     render() {
-        let childComponents = [];
+        let tabSetComponents = [];
+        let tabComponents = {};
+        let splitterComponents = [];
+
         this.model._layout(this.rect);
-        this.renderChildren(this.model.getRoot(), childComponents);
-        return <div ref="self" className="flexlayout__layout">{childComponents}</div>;
+        this.renderChildren(this.model.getRoot(), tabSetComponents, tabComponents, splitterComponents);
+
+        const nextToIds = [];
+        // Keep any previous tabs in the same DOM order as before, removing any that have been deleted
+        this.tabIds.forEach(t => {
+            if (Object.keys(tabComponents).find(tt => t === tt)) {
+                nextTopIds.push(t);
+            }
+        });
+        this.tabIds = nextTopIds;
+
+        // Add tabs that have been added to the DOM
+        Object.keys(tabComponents).forEach(t => {
+            if (!this.tabIds.find(tt => t === tt)) {
+              this.tabIds.push(t);
+            }
+        });
+
+        return (
+            <div ref="self" className="flexlayout__layout">
+                {tabSetComponents}
+                {this.tabIds.map(t => {
+                    return tabComponents[t];
+                })}
+                {splitterComponents}
+            </div>
+        );
     }
 
-    renderChildren(node, childComponents) {
+    renderChildren(node, tabSetComponents, tabComponents, splitterComponents) {
         let drawChildren = node._getDrawChildren();
         this.maximized = false;
         for (let i = 0; i < drawChildren.length; i++) {
             let child = drawChildren[i];
 
             if (child.getType() === SplitterNode.TYPE) {
-                childComponents.push(<Splitter key={child.getId()} layout={this} node={child}></Splitter>);
+                splitterComponents.push(<Splitter key={child.getId()} layout={this} node={child}></Splitter>);
             }
             else if (child.getType() === TabSetNode.TYPE) {
-                childComponents.push(<TabSet key={child.getId()} layout={this} node={child}></TabSet>);
-                this.renderChildren(child, childComponents);
+                tabSetComponents.push(<TabSet key={child.getId()} layout={this} node={child}></TabSet>);
+                this.renderChildren(child, tabSetComponents, tabComponents, splitterComponents);
                 if (child.isMaximized()) {
                     this.maximized = true;
                 }
@@ -108,16 +137,16 @@ class Layout extends React.Component {
                 if (selectedTab == null) {
                     debugger; // this should not happen!
                 }
-                childComponents.push(<Tab
+                tabComponents[child.getId()] = <Tab
                     key={child.getId()}
                     layout={this}
                     node={child}
                     selected={child === selectedTab}
                     factory={this.props.factory}>
-                </Tab>);
+                </Tab>;
             }
             else {// is row
-                this.renderChildren(child, childComponents);
+                this.renderChildren(child, tabSetComponents, tabComponents, splitterComponents);
             }
         }
     }
@@ -125,7 +154,6 @@ class Layout extends React.Component {
     log(message) {
         console.log(message);
     }
-
 
     /**
      * Adds a new tab to the given tabset
@@ -294,7 +322,6 @@ class Layout extends React.Component {
         this.dragDiv = null;
         this.hideEdges(rootdiv);
         DragDrop.instance.hideGlass();
-
 
         if (this.dropInfo) {
             if (this.newTabJson != null) {


### PR DESCRIPTION
When a tab is moved the component is rendered either up or down in the DOM. If the component moves down it is re-rendered by react. When the component contains certain elements like iframe and object tag this causes them to reload and lose and state within the tag. The react developers are not planning to fix this behaviour.

This PR ensures that tabs are rendered in a consistent order in the DOM so that when they move in the tree they do not move in the DOM. Tabset components are rendered first so as not to break the rendering, and splitters last.