### PR TITLE
Enable/Disable Truncation 

### DIFF
--- a/src/model/TabSetNode.js
+++ b/src/model/TabSetNode.js
@@ -352,7 +352,8 @@ attributeDefinitions.add("weight", 100);
 attributeDefinitions.add("width", null);
 attributeDefinitions.add("height", null);
 attributeDefinitions.add("selected", 0);
-attributeDefinitions.add("name", null).setType(Attribute.STRING);
+attributeDefinitions.add("name", null);
+attributeDefinitions.add("enableTabTruncate", true, true).setType(Attribute.BOOLEAN);
 
 attributeDefinitions.addInherited("enableDeleteWhenEmpty", "tabSetEnableDeleteWhenEmpty");
 attributeDefinitions.addInherited("enableClose", "tabSetEnableClose");

--- a/src/view/TabSet.js
+++ b/src/view/TabSet.js
@@ -33,7 +33,7 @@ class TabSet extends React.Component {
     updateVisibleTabs() {
         const node = this.props.node;
 
-        if (node.isEnableTabStrip() && this.recalcVisibleTabs) {
+        if (node.isEnableTabStrip() && this.recalcVisibleTabs && node._attributes.enableTabTruncate) {
             const toolbarWidth = this.refs.toolbar.getBoundingClientRect().width;
             let hideTabsAfter = 999;
             for (let i = 0; i < node.getChildren().length; i++) {
@@ -56,8 +56,8 @@ class TabSet extends React.Component {
             if (this.state.hideTabsAfter !== hideTabsAfter) {
                 this.setState({hideTabsAfter: hideTabsAfter});
             }
-            this.recalcVisibleTabs = false;
         }
+        this.recalcVisibleTabs = false;
     }
 
     render() {


### PR DESCRIPTION
We needed a way to disable the truncation of tabs, as we would like all of them to be visible and styled/resized according to available size they can occupy.