### PR TITLE
Fix case sensitivity of the node_modules path

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ import FlexLayout from "flexlayout-react";
 Include the light or dark style in your html:
 
 ```
-<link rel="stylesheet" href="node_modules/flexLayout-react/style/dark.css" />
+<link rel="stylesheet" href="node_modules/flexlayout-react/style/dark.css" />
 ```
 
 ## Usage


### PR DESCRIPTION
On linux, file name casing matters. 
The directory in `node_modules` is named `flexlayout-react` with a lowercase `l`, trying to include css styles using `node_modules/flexLayout-react/...` with an uppercase `L` does not work on linux (tested with the parcel bundler)