### PR TITLE
Add tabDragSpeed global attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ Attributes allowed in the 'global' element
 | tabClassName | null | |
 | tabIcon | null | |
 | tabEnableRenderOnDemand | true | |
+| tabDragSpeed | 0.3 | CSS transition speed of drag outlines (in seconds) |
 | tabSetEnableDeleteWhenEmpty | true | |
 | tabSetEnableDrop | true | |
 | tabSetEnableDrag | true | |

--- a/src/model/Model.ts
+++ b/src/model/Model.ts
@@ -410,6 +410,7 @@ class Model {
         attributeDefinitions.add("tabClassName", undefined).setType(Attribute.STRING);
         attributeDefinitions.add("tabIcon", undefined).setType(Attribute.STRING);
         attributeDefinitions.add("tabEnableRenderOnDemand", true).setType(Attribute.BOOLEAN);
+        attributeDefinitions.add("tabDragSpeed", 0.3).setType(Attribute.NUMBER);
 
         // tabset
         attributeDefinitions.add("tabSetEnableDeleteWhenEmpty", true).setType(Attribute.BOOLEAN);

--- a/src/view/Layout.tsx
+++ b/src/view/Layout.tsx
@@ -414,7 +414,8 @@ export class Layout extends React.Component<ILayoutProps, any> {
     /** @hidden @internal */
     onDragMove(event: React.MouseEvent<Element>) {
         if (this.firstMove === false) {
-            this.outlineDiv!.style.transition = "top .3s, left .3s, width .3s, height .3s";
+            const speed = this.model!._getAttribute("tabDragSpeed") as number;
+            this.outlineDiv!.style.transition = `top ${speed}s, left ${speed}s, width ${speed}s, height ${speed}s`;
         }
         this.firstMove = false;
         const clientRect = this.selfRef!.getBoundingClientRect();


### PR DESCRIPTION
I noticed the CSS transition speed for the tab drag outline was hard-coded at 0.3 seconds. I found this to be a bit slow for my taste. This PR would make it customizable via a global attribute.

Another option would be to move it out of code and into CSS. Both options have pros and cons, but an attribute met my needs well, so I went with that. If you disagree with the approach, I'm happy to discuss.

If you want to rename `tabDragSpeed` to something else, I don't mind. I just care about the functionality.

Thank you!