### PR TITLE
onAction implementation allows doAction when action returned

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,15 +65,15 @@ Include the light or dark style in your html:
 The `<Layout>` component renders the tabsets and splitters, it takes the following props:
 
 
-| Prop       | Required/Optional           | Description  |
-| ------------- |:-------------:| -----|
-| model    | required | the layout model  |
-| factory      | required | a factory function for creating React components |
-| onAction | optional     |  function called whenever the layout generates an action to update the model (allows for intercepting actions before they are dispatched to the model, for example, asking the user to confirm a tab close) |
-| onRenderTab | optional     |  function called when rendering a tab, allows leading (icon) and content sections to be customized |
-| onRenderTabSet | optional     |  function called when rendering a tabset, allows header and buttons to be customized |
-| onModelChange | optional     |  function called when model has changed  |
-| classNameMapper | optional     |  function called with default css class name, return value is class name that will be used. Mainly for use with css modules.|
+| Prop            | Required/Optional | Description       |
+| --------------- |:-----------------:| ----------------- |
+| model           | required          | the layout model  |
+| factory         | required          | a factory function for creating React components |
+| onAction        | optional          | function called whenever the layout generates an action to update the model (allows for intercepting actions before they are dispatched to the model, for example, asking the user to confirm a tab close.) Returning `undefined` from the function will halt the action, otherwise return the action to continue |
+| onRenderTab     | optional          | function called when rendering a tab, allows leading (icon) and content sections to be customized |
+| onRenderTabSet  | optional          | function called when rendering a tabset, allows header and buttons to be customized |
+| onModelChange   | optional          | function called when model has changed |
+| classNameMapper | optional          | function called with default css class name, return value is class name that will be used. Mainly for use with css modules.|
 
 The model is tree of Node objects that define the structure of the layout.
 

--- a/src/view/Layout.tsx
+++ b/src/view/Layout.tsx
@@ -23,7 +23,7 @@ import IDraggable from "../model/IDraggable";
 export interface ILayoutProps {
     model: Model,
     factory: (node: TabNode) => React.ReactNode,
-    onAction?: (action: Action) => void,
+    onAction?: (action: Action) => Action | undefined,
     onRenderTab?: (node: TabNode, renderValues: { leading: React.ReactNode, content: React.ReactNode }) => void,
     onRenderTabSet?: (tabSetNode: (TabSetNode | BorderNode), renderValues: { headerContent?: React.ReactNode, buttons: Array<React.ReactNode> }) => void,
     onModelChange?: (model: Model) => void,
@@ -96,9 +96,12 @@ export class Layout extends React.Component<ILayoutProps, any> {
     }
 
     /** @hidden @internal */
-    doAction(action: Action) : void{
+    doAction(action: Action): void {
         if (this.props.onAction !== undefined) {
-            this.props.onAction(action);
+            const outcome = this.props.onAction(action);
+            if (outcome !== undefined) {
+                this.model!.doAction(outcome);
+            }
         }
         else {
             this.model!.doAction(action);


### PR DESCRIPTION
Non-breaking change.

Currently, we halt processing an action if an implementation for onAction has been provided.
We can enhance this by allowing the implementation to optionally return the action, or choose not too.
Therefore the onAction truly does become an interception of the action.