### PR TITLE
onModelChange API include action

### DIFF
--- a/src/model/Model.ts
+++ b/src/model/Model.ts
@@ -30,7 +30,7 @@ class Model {
     /** @hidden @internal */
     private _nextId: number;
     /** @hidden @internal */
-    private _changeListener?: (() => void) ;
+    private _changeListener?: ((action: Action) => void) ;
     /** @hidden @internal */
     private _root?: RowNode;
     /** @hidden @internal */
@@ -57,7 +57,7 @@ class Model {
     }
 
      /** @hidden @internal */
-     _setChangeListener(listener: (() => void) | undefined) {
+     _setChangeListener(listener: ((action: Action) => void) | undefined) {
         this._changeListener = listener;
     }
 
@@ -253,7 +253,7 @@ class Model {
         this._updateIdMap();
 
         if (this._changeListener !== undefined) {
-            this._changeListener();
+            this._changeListener(action);
         }
     }
 

--- a/src/view/Layout.tsx
+++ b/src/view/Layout.tsx
@@ -26,7 +26,7 @@ export interface ILayoutProps {
     onAction?: (action: Action) => Action | undefined,
     onRenderTab?: (node: TabNode, renderValues: { leading: React.ReactNode, content: React.ReactNode }) => void,
     onRenderTabSet?: (tabSetNode: (TabSetNode | BorderNode), renderValues: { headerContent?: React.ReactNode, buttons: Array<React.ReactNode> }) => void,
-    onModelChange?: (model: Model) => void,
+    onModelChange?: (model: Model, action: Action) => void,
     classNameMapper?: (defaultClassName: string) => string
 }
 
@@ -88,10 +88,10 @@ export class Layout extends React.Component<ILayoutProps, any> {
     }
 
     /** @hidden @internal */
-    onModelChange() {
+    onModelChange(action: Action) {
         this.forceUpdate();
         if (this.props.onModelChange) {
-            this.props.onModelChange(this.model!)
+            this.props.onModelChange(this.model!, action)
         }
     }
 


### PR DESCRIPTION
Non-breaking change.

Enhance the onModelChange API by including the action as one of the parameters.

Helpful when looking to see why a model change has occurred.