### PR TITLE
Removes react unsafe lifecycle warnings

### DIFF
--- a/src/view/Layout.tsx
+++ b/src/view/Layout.tsx
@@ -120,7 +120,7 @@ export class Layout extends React.Component<ILayoutProps, any> {
   }
 
   /** @hidden @internal */
-  componentWillReceiveProps(newProps: ILayoutProps) {
+  UNSAFE_componentWillReceiveProps(newProps: ILayoutProps) {
     if (this.model !== newProps.model) {
       if (this.model !== undefined) {
         this.model._setChangeListener(undefined); // stop listening to old model

--- a/src/view/Tab.tsx
+++ b/src/view/Tab.tsx
@@ -29,7 +29,7 @@ export class Tab extends React.Component<ITabProps, any> {
         // console.log("unmount " + this.props.node.getName());
     }
 
-    componentWillReceiveProps(newProps: ITabProps) {
+    UNSAFE_componentWillReceiveProps(newProps: ITabProps) {
         if (!this.state.renderComponent && newProps.selected) {
             // load on demand
             // console.log("load on demand: " + this.props.node.getName());

--- a/src/view/TabSet.tsx
+++ b/src/view/TabSet.tsx
@@ -39,7 +39,7 @@ export class TabSet extends React.Component<ITabSetProps, any> {
         this.updateVisibleTabs();
     }
 
-    componentWillReceiveProps(nextProps: ITabSetProps) {
+    UNSAFE_componentWillReceiveProps(nextProps: ITabSetProps) {
         this.showToolbar = true;
         this.showOverflow = false;
         this.recalcVisibleTabs = true;


### PR DESCRIPTION
-  Ran the following codemod `npx react-codemod rename-unsafe-lifecycles`to rename all deprecated lifecycles to their new names. 