### PR TITLE
Check global variables existence before usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flexlayout-react",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "A multi-tab docking layout manager",
   "main": "lib/index.js",
   "types": "./declarations/index.d.ts",

--- a/src/view/Layout.tsx
+++ b/src/view/Layout.tsx
@@ -84,8 +84,8 @@ export interface ILayoutCallbacks {
 // not work on any version if IE or the original Edge browser
 // Assume any recent browser not IE or original Edge will work
 // @ts-ignore
-const isIEorEdge = document.documentMode || /Edge\//.test(navigator.userAgent);
-const isMobile = /iPhone|iPad|Android/i.test(navigator.userAgent);
+const isIEorEdge = typeof window !== "undefined" && (window.document.documentMode || /Edge\//.test(window.navigator.userAgent));
+const isMobile = typeof window !== "undefined" && /iPhone|iPad|Android/i.test(window.navigator.userAgent);
 const defaultSupportsPopout: boolean = !isIEorEdge && !isMobile;
 
 /**


### PR DESCRIPTION
This diff fixes error when library is imported in nodejs. (often happens
with server side rendering and test environments).

fix #115