### PR TITLE
Use window size to place popup menus

### DIFF
--- a/src/PopupMenu.tsx
+++ b/src/PopupMenu.tsx
@@ -9,20 +9,28 @@ export function showPopup(triggerElement: Element,
 
     const triggerRect = triggerElement.getBoundingClientRect();
     const currentDocument = triggerElement.ownerDocument;
-
-    const docRect = currentDocument.body.getBoundingClientRect();
+    const currentWindow = currentDocument.defaultView;
+    let windowWidth, windowHeight;
+    if (currentWindow) {
+      windowWidth = currentWindow.innerWidth;
+      windowHeight = currentWindow.innerHeight;
+    } else {
+      const docRect = currentDocument.body.getBoundingClientRect();
+      windowWidth = docRect.right;
+      windowHeight = docRect.bottom;
+    }
 
     const elm = currentDocument.createElement("div");
     elm.className = classNameMapper("flexlayout__popup_menu_container");
-    if (triggerRect.left < docRect.width / 2) {
+    if (triggerRect.left < windowWidth / 2) {
         elm.style.left = (triggerRect.left) + "px";
     } else {
-        elm.style.right = (docRect.right - triggerRect.right) + "px";
+        elm.style.right = (windowWidth - triggerRect.right) + "px";
     }
-    if (triggerRect.top < docRect.height / 2) {
+    if (triggerRect.top < windowHeight / 2) {
         elm.style.top = (triggerRect.top) + "px";
     } else {
-        elm.style.bottom = (docRect.bottom - triggerRect.bottom) + "px";
+        elm.style.bottom = (windowHeight - triggerRect.bottom) + "px";
     }
     currentDocument.body.appendChild(elm);
 


### PR DESCRIPTION
The existing popup placement code uses the document's width and height to place the popups, but they're placed via `position:absolute` to window-relative coordinates. This has two issues:

1. If the document is scrollable, then the popup will appear in the wrong place. I tested that this is indeed the case on the demo by adding a lot of flowed text in the background (a bunch of toolbars), removing `overflow:auto`, scrolling, and then clicking on a popup button:

   ![screenshot](https://user-images.githubusercontent.com/2218736/89921985-715db780-dbcc-11ea-8ec9-a5af572866df.png)

2. If the document consists entirely of a FlexLayout, as it does in my application, then because it's absolutely positioned, the document has zero height. This leads to very wrong placement of the popup menu (below the bottom of the window).

This PR uses the document's window size, if it's available, and falls back to the old method otherwise (apparently `currentView` can sometimes be `null`).

I've tested it in my own system and it fixed Issue 2 above.