### PR TITLE
Publish src directory

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,7 +4,6 @@ bundles/
 examples/
 node_modules/
 spec/
-src/
 typedoc/
 package-lock.json
 todo.txt


### PR DESCRIPTION
This simple PR publishes the `src` directory on NPM, or more precisely, removes it from `.npmignore`. This has two main advantages:
1. Those writing their application in TypeScript can use the source code directly instead of the built `lib` code, via `import FlexLayout from "flexlayout-react/src/index"`.
2. If you `npm install` from Github instead of NPM, then you get an actually workable copy of the repository. (`npm install` won't take anything listed in `.npmignore`.) This is useful to me for using not-yet-released-to-NPM versions, as I can easily add TypeScript to my build chain.

There are other things that would make this install-from-Github experience better, like [defining a `prepare` script](https://blog.jim-nielsen.com/2018/installing-and-building-an-npm-package-from-github/#installing-and-building-packages-with-npm-from-github), but this is a start that suffices for my purposes.