### PR TITLE
Custom icon support via icons prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The `<Layout>` component renders the tabsets and splitters, it takes the followi
 | factory         | required          | a factory function for creating React components |
 | iconFactory     | optional          | a factory function for creating icon components for tab bar buttons |
 | titleFactory    | optional          | a factory function for creating title components for tab bar buttons |
-| closeIcon       | optional          | a icon to use in place of the default close icon |
+| icons           | optional          | object mapping keys among `close`, `maximize`, `restore`, `more`, `popout` to React nodes to use in place of the default icons |
 | onAction        | optional          | function called whenever the layout generates an action to update the model (allows for intercepting actions before they are dispatched to the model, for example, asking the user to confirm a tab close.) Returning `undefined` from the function will halt the action, otherwise return the action to continue |
 | onRenderTab     | optional          | function called when rendering a tab, allows leading (icon) and content sections to be customized |
 | onRenderTabSet  | optional          | function called when rendering a tabset, allows header and buttons to be customized |

--- a/src/view/BorderButton.tsx
+++ b/src/view/BorderButton.tsx
@@ -3,7 +3,7 @@ import {I18nLabel} from "..";
 import Actions from "../model/Actions";
 import TabNode from "../model/TabNode";
 import Rect from "../Rect";
-import {ILayoutCallbacks} from "./Layout";
+import {IIcons, ILayoutCallbacks} from "./Layout";
 
 /** @hidden @internal */
 export interface IBorderButtonProps {
@@ -13,12 +13,12 @@ export interface IBorderButtonProps {
     border: string;
     iconFactory?: (node: TabNode) => React.ReactNode | undefined;
     titleFactory?: (node: TabNode) => React.ReactNode | undefined;
-    closeIcon?: React.ReactNode;
+    icons?: IIcons;
 }
 
 /** @hidden @internal */
 export const BorderButton = (props: IBorderButtonProps) => {
-    const {layout, node, selected, border, iconFactory, titleFactory, closeIcon} = props;
+    const {layout, node, selected, border, iconFactory, titleFactory, icons} = props;
     const selfRef = React.useRef<HTMLDivElement | null>(null);
 
     const onMouseDown = (event: React.MouseEvent<HTMLDivElement, MouseEvent> | React.TouchEvent<HTMLDivElement>) => {
@@ -90,7 +90,7 @@ export const BorderButton = (props: IBorderButtonProps) => {
                            onMouseDown={onCloseMouseDown}
                            onClick={onClose}
                            onTouchStart={onCloseMouseDown}
-        >{closeIcon}</div>;
+        >{icons?.close}</div>;
     }
 
     return <div ref={selfRef}

--- a/src/view/BorderTabSet.tsx
+++ b/src/view/BorderTabSet.tsx
@@ -3,7 +3,7 @@ import DockLocation from "../DockLocation";
 import Border from "../model/BorderNode";
 import TabNode from "../model/TabNode";
 import {BorderButton} from "./BorderButton";
-import {ILayoutCallbacks} from "./Layout";
+import {IIcons, ILayoutCallbacks} from "./Layout";
 import {showPopup} from "../PopupMenu";
 import Actions from "../model/Actions";
 import {getModifiedNodeList} from "./TabSet";
@@ -15,14 +15,14 @@ export interface IBorderTabSetProps {
     layout: ILayoutCallbacks;
     iconFactory?: (node: TabNode) => React.ReactNode | undefined;
     titleFactory?: (node: TabNode) => React.ReactNode | undefined;
-    closeIcon?: React.ReactNode;
+    icons?: IIcons;
 }
 
 const MAX_TABS: number = 999;
 
 /** @hidden @internal */
 export const BorderTabSet = (props: IBorderTabSetProps) => {
-    const {border, layout, iconFactory, titleFactory, closeIcon} = props;
+    const {border, layout, iconFactory, titleFactory, icons} = props;
 
     const toolbarRef = React.useRef<HTMLDivElement | null>(null);
     const overflowbuttonRef = React.useRef<HTMLButtonElement | null>(null);
@@ -151,7 +151,7 @@ export const BorderTabSet = (props: IBorderTabSetProps) => {
                                     selected={isSelected}
                                     iconFactory={iconFactory}
                                     titleFactory={titleFactory}
-                                    closeIcon={closeIcon}/>);
+                                    icons={icons}/>);
         }
     };
 

--- a/src/view/Layout.tsx
+++ b/src/view/Layout.tsx
@@ -29,6 +29,7 @@ export interface ILayoutProps {
     iconFactory?: (node: TabNode) => React.ReactNode | undefined;
     titleFactory?: (node: TabNode) => React.ReactNode | undefined;
     closeIcon?: React.ReactNode;
+    icons?: IIcons;
     onAction?: (action: Action) => Action | undefined;
     onRenderTab?: (
         node: TabNode,
@@ -46,6 +47,14 @@ export interface ILayoutProps {
     i18nMapper?: (id: I18nLabel, param?: string) => string | undefined;
     supportsPopout?: boolean | undefined;
     popoutURL?: string | undefined;
+}
+
+export interface IIcons {
+    close?: React.ReactNode;
+    popout?: React.ReactNode;
+    maximize?: React.ReactNode;
+    restore?: React.ReactNode;
+    more?: React.ReactNode;
 }
 
 /** @hidden @internal */
@@ -144,6 +153,8 @@ export class Layout extends React.Component<ILayoutProps, any>  {
     private supportsPopout: boolean;
     /** @hidden @internal */
     private popoutURL: string;
+    /** @hidden @internal */
+    private icons?: IIcons;
     private firstRender: boolean;
 
     constructor(props: ILayoutProps) {
@@ -156,6 +167,10 @@ export class Layout extends React.Component<ILayoutProps, any>  {
         this.selfRef = React.createRef<HTMLDivElement>();
         this.supportsPopout = props.supportsPopout !== undefined ? props.supportsPopout : defaultSupportsPopout;
         this.popoutURL = props.popoutURL ? props.popoutURL : "popout.html";
+        // For backwards compatibility, prop closeIcon sets prop icons.close:
+        this.icons = props.closeIcon ?
+            Object.assign({close: props.closeIcon}, props.icons) :
+            props.icons;
         this.firstRender = true;
     }
 
@@ -354,7 +369,7 @@ export class Layout extends React.Component<ILayoutProps, any>  {
                         layout={this}
                         iconFactory={this.props.iconFactory}
                         titleFactory={this.props.titleFactory}
-                        closeIcon={this.props.closeIcon}
+                        icons={this.icons}
                     />
                 );
                 const drawChildren = border._getDrawChildren();
@@ -431,7 +446,7 @@ export class Layout extends React.Component<ILayoutProps, any>  {
                         node={child}
                         iconFactory={this.props.iconFactory}
                         titleFactory={this.props.titleFactory}
-                        closeIcon={this.props.closeIcon}
+                        icons={this.icons}
                     />
                 );
                 this.renderChildren(

--- a/src/view/TabButton.tsx
+++ b/src/view/TabButton.tsx
@@ -4,7 +4,7 @@ import Actions from "../model/Actions";
 import TabNode from "../model/TabNode";
 import TabSetNode from "../model/TabSetNode";
 import Rect from "../Rect";
-import {ILayoutCallbacks} from "./Layout";
+import {IIcons, ILayoutCallbacks} from "./Layout";
 
 /** @hidden @internal */
 export interface ITabButtonProps {
@@ -15,12 +15,12 @@ export interface ITabButtonProps {
     height: number;
     iconFactory?: (node: TabNode) => React.ReactNode | undefined;
     titleFactory?: (node: TabNode) => React.ReactNode | undefined;
-    closeIcon?: React.ReactNode;
+    icons?: IIcons;
 }
 
 /** @hidden @internal */
 export const TabButton = (props: ITabButtonProps) => {
-    const {layout, node, show, selected, height, iconFactory, titleFactory, closeIcon} = props;
+    const {layout, node, show, selected, height, iconFactory, titleFactory, icons} = props;
     const selfRef = React.useRef<HTMLDivElement | null>(null);
     const contentRef = React.useRef<HTMLInputElement | null>(null);
     const contentWidth = React.useRef<number>(0);
@@ -142,7 +142,7 @@ export const TabButton = (props: ITabButtonProps) => {
                            onMouseDown={onCloseMouseDown}
                            onClick={onClose}
                            onTouchStart={onCloseMouseDown}
-        >{closeIcon}</div>;
+        >{icons?.close}</div>;
     }
 
     return <div ref={selfRef}

--- a/src/view/TabSet.tsx
+++ b/src/view/TabSet.tsx
@@ -4,7 +4,7 @@ import Actions from "../model/Actions";
 import TabNode from "../model/TabNode";
 import TabSetNode from "../model/TabSetNode";
 import {showPopup} from "../PopupMenu";
-import {ILayoutCallbacks} from "./Layout";
+import {IIcons, ILayoutCallbacks} from "./Layout";
 import {TabButton} from "./TabButton";
 
 /** @hidden @internal */
@@ -13,7 +13,7 @@ export interface ITabSetProps {
     node: TabSetNode;
     iconFactory?: (node: TabNode) => React.ReactNode | undefined;
     titleFactory?: (node: TabNode) => React.ReactNode | undefined;
-    closeIcon?: React.ReactNode;
+    icons?: IIcons;
 }
 
 const MAX_TABS: number = 999;
@@ -45,7 +45,7 @@ export function getModifiedNodeList(nodes: TabNode[], selectedIndex: number): Ta
 
 /** @hidden @internal */
 export const TabSet = (props: ITabSetProps) => {
-    const {node, layout, iconFactory, titleFactory, closeIcon} = props;
+    const {node, layout, iconFactory, titleFactory, icons} = props;
 
     const toolbarRef = React.useRef<HTMLDivElement | null>(null);
     const overflowbuttonRef = React.useRef<HTMLButtonElement | null>(null);
@@ -180,7 +180,7 @@ export const TabSet = (props: ITabSetProps) => {
                                      height={node.getTabStripHeight()}
                                      iconFactory={iconFactory}
                                      titleFactory={titleFactory}
-                                     closeIcon={closeIcon}/>);
+                                     icons={icons}/>);
             }
         }
     }
@@ -201,7 +201,8 @@ export const TabSet = (props: ITabSetProps) => {
             buttons.push(<button key="float"
                                  title={floatTitle}
                                  className={cm("flexlayout__tab_toolbar_button-float")}
-                                 onClick={onFloatTab}/>);
+                                 onClick={onFloatTab}
+            >{icons?.popout}</button>);
         }
         if (node.isEnableMaximize()) {
             const minTitle = layout.i18nName(I18nLabel.Restore);
@@ -209,7 +210,8 @@ export const TabSet = (props: ITabSetProps) => {
             buttons.push(<button key="max"
                                  title={node.isMaximized() ? minTitle : maxTitle}
                                  className={cm("flexlayout__tab_toolbar_button-" + (node.isMaximized() ? "max" : "min"))}
-                                 onClick={onMaximizeToggle}/>);
+                                 onClick={onMaximizeToggle}
+            >{node.isMaximized() ? icons?.restore : icons?.maximize}</button>);
         }
 
         toolbar = <div key="toolbar" ref={toolbarRef} className={cm("flexlayout__tab_toolbar")}
@@ -224,7 +226,7 @@ export const TabSet = (props: ITabSetProps) => {
                           onTouchStart={onInterceptMouseDown}
                           onClick={onOverflowClick}
                           onMouseDown={onInterceptMouseDown}
-        >{hiddenTabs.length}</button>);
+        >{icons?.more}{hiddenTabs.length}</button>);
     }
 
     const showHeader = node.getName() !== undefined;


### PR DESCRIPTION
Fix #130 as proposed: implement a general `icons` prop with allowed keys of `close`, `maximize`, `restore`, `more`, and `popout`. (There were other choices for these names used within the code and CSS; I chose to match the filenames in `images` but am happy to change them.)  `closeIcon` is still supported for backward compatibility (its value gets put into `icons.close`); let me know if you'd rather remove that.  (I did remove it from the documentation to encourage the new system.)

The implementations mimic the existing implementation of `closeIcon` in that it adds the specified React node to the `<button>`, but it doesn't actually stop the existing CSS from rendering the old button as a background. This is still really helpful, because it's easy to override the CSS.  But we could explore (in this PR or another) the possibility of changing the CSS class according to whether the button is overridden.  Let me know what you prefer.  To give you a sense, here are some of the CSS overrides that are probably needed:

```css
.flexlayout__tab_button_trailing,
.flexlayout__border_button_trailing { margin-top: 0; background: transparent; }
.flexlayout__tab_button_overflow,
.flexlayout__border_button_overflow { width: auto; padding-left: 6px; background: transparent; }
.flexlayout__tab_tab_toolbar_button-min,
.flexlayout__tab_tab_toolbar_button-max,
.flexlayout__tab_tab_toolbar_button-float,
.flexlayout__border_button_overflow_top,
.flexlayout__border_button_overflow_bottom,
.flexlayout__border_button_overflow_right,
.flexlayout__border_button_overflow_left { background: transparent; }
```