### PR TITLE
Allow customizeTab to add custom buttons to tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ The `<Layout>` component renders the tabsets and splitters, it takes the followi
 | titleFactory    | optional          | a factory function for creating title components for tab bar buttons |
 | icons           | optional          | object mapping keys among `close`, `maximize`, `restore`, `more`, `popout` to React nodes to use in place of the default icons |
 | onAction        | optional          | function called whenever the layout generates an action to update the model (allows for intercepting actions before they are dispatched to the model, for example, asking the user to confirm a tab close.) Returning `undefined` from the function will halt the action, otherwise return the action to continue |
-| onRenderTab     | optional          | function called when rendering a tab, allows leading (icon) and content sections to be customized |
+| onRenderTab     | optional          | function called when rendering a tab, allows leading (icon), content sections, and buttons to be customized |
 | onRenderTabSet  | optional          | function called when rendering a tabset, allows header and buttons to be customized |
 | onModelChange   | optional          | function called when model has changed |
 | classNameMapper | optional          | function called with default css class name, return value is class name that will be used. Mainly for use with css modules.|

--- a/package.json
+++ b/package.json
@@ -54,6 +54,5 @@
     "webpack-cli": "^3.3.12",
     "webpack-dev-server": "^3.11.0"
   },
-  "dependencies": {
-  }
+  "dependencies": {}
 }

--- a/src/I18nLabel.ts
+++ b/src/I18nLabel.ts
@@ -1,4 +1,5 @@
 export enum I18nLabel {
+    Close_Tab = "Close",
     Move_Tab = "Move: ",
     Move_Tabset = "Move tabset",
     Maximize = "Maximize",

--- a/src/view/BorderButton.tsx
+++ b/src/view/BorderButton.tsx
@@ -77,20 +77,24 @@ export const BorderButton = (props: IBorderButtonProps) => {
         leadingContent = <img src={node.getIcon()} alt="leadingContent"/>;
     }
 
+    let buttons: any[] = [];
+
     // allow customization of leading contents (icon) and contents
-    const renderState = {leading: leadingContent, content: titleContent};
+    const renderState = {leading: leadingContent, content: titleContent, buttons};
     layout.customizeTab(node, renderState);
 
     const content = <div className={cm("flexlayout__border_button_content")}>{renderState.content}</div>;
     const leading = <div className={cm("flexlayout__border_button_leading")}>{renderState.leading}</div>;
 
-    let closeButton;
     if (node.isEnableClose()) {
-        closeButton = <div className={cm("flexlayout__border_button_trailing")}
-                           onMouseDown={onCloseMouseDown}
-                           onClick={onClose}
-                           onTouchStart={onCloseMouseDown}
-        >{icons?.close}</div>;
+        const closeTitle = layout.i18nName(I18nLabel.Close_Tab);
+        buttons.push(<div key="close"
+                          title={closeTitle}
+                          className={cm("flexlayout__border_button_trailing")}
+                          onMouseDown={onCloseMouseDown}
+                          onClick={onClose}
+                          onTouchStart={onCloseMouseDown}
+        >{icons?.close}</div>);
     }
 
     return <div ref={selfRef}
@@ -100,6 +104,6 @@ export const BorderButton = (props: IBorderButtonProps) => {
                 onTouchStart={onMouseDown}>
         {leading}
         {content}
-        {closeButton}
+        {buttons}
     </div>;
 };

--- a/src/view/TabButton.tsx
+++ b/src/view/TabButton.tsx
@@ -115,8 +115,10 @@ export const TabButton = (props: ITabButtonProps) => {
         leadingContent = <img src={node.getIcon()} alt="leadingContent"/>;
     }
 
+    let buttons: any[] = [];
+
     // allow customization of leading contents (icon) and contents
-    const renderState = {leading: leadingContent, content: titleContent};
+    const renderState = {leading: leadingContent, content: titleContent, buttons};
     layout.customizeTab(node, renderState);
 
     let content = <div ref={contentRef} className={cm("flexlayout__tab_button_content")}>{renderState.content}</div>;
@@ -136,13 +138,15 @@ export const TabButton = (props: ITabButtonProps) => {
         />;
     }
 
-    let closeButton;
     if (node.isEnableClose()) {
-        closeButton = <div className={cm("flexlayout__tab_button_trailing")}
-                           onMouseDown={onCloseMouseDown}
-                           onClick={onClose}
-                           onTouchStart={onCloseMouseDown}
-        >{icons?.close}</div>;
+        const closeTitle = layout.i18nName(I18nLabel.Close_Tab);
+        buttons.push(<div key="close"
+                          title={closeTitle}
+                          className={cm("flexlayout__tab_button_trailing")}
+                          onMouseDown={onCloseMouseDown}
+                          onClick={onClose}
+                          onTouchStart={onCloseMouseDown}
+        >{icons?.close}</div>);
     }
 
     return <div ref={selfRef}
@@ -155,6 +159,6 @@ export const TabButton = (props: ITabButtonProps) => {
                 onTouchStart={onMouseDown}>
         {leading}
         {content}
-        {closeButton}
+        {buttons}
     </div>;
 };


### PR DESCRIPTION
Currently, the `customizeTabSet` callback is given an empty `buttons` list to which the user can add custom buttons.  But the analogous `customizeTab` does not; only the close button gets rendered.  This PR unifies the two by passing in a similar `buttons` array to `customizeTab`.  The code is very similar to the `customizeTabSet` case.

This is a little awkward to use because buttons in this context because, in addition to defining an `onClick` helper, the user also needs to define an `onMouseDown` and `onTouchStart` helpers with value `(e) => e.preventDefault()`.  (This took me a while to figure out, but the close button does it, and it's to deal with tab renaming.)  This would probably be good to document somewhere, but I wasn't sure where.

While I was here, I also added a missing `title` attribute to the close button.