### PR TITLE
Allow adding and moving tabs without selecting them

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,8 +451,8 @@ adjusting the layout easier on a small device.
 
 | Action Creator | Description  |
 | ------------- | -----|
-|	Actions.addNode(newNodeJson, toNodeId, location, index) | add a new tab node to the given tabset node  |
-|	Actions.moveNode(fromNodeId, toNodeId, location, index) | move a tab node from its current location to the new node and location |
+|	Actions.addNode(newNodeJson, toNodeId, location, index, doNotSelect?) | add a new tab node to the given tabset node, and select it unless doNotSelect is true |
+|	Actions.moveNode(fromNodeId, toNodeId, location, index, doNotSelect?) | move a tab node from its current location to the new node and location, and select it unless doNotSelect is true |
 |	Actions.deleteTab(tabNodeId) | delete the given tab |
 |	Actions.selectTab(tabNodeId) | select the given tab |
 |	Actions.setActiveTabset(tabsetNodeId) | set the tabset as the active tabset |

--- a/README.md
+++ b/README.md
@@ -328,6 +328,7 @@ Attributes allowed in the 'global' element
 | tabSetEnableDrag | true | |
 | tabSetEnableDivide | true | |
 | tabSetEnableMaximize | true | |
+| tabSetAutoSelectTab | true | whether to select new/moved tabs in tabset |
 | tabSetClassNameTabStrip | null | |
 | tabSetClassNameHeader | null | |
 | tabSetEnableTabStrip | true | |
@@ -335,6 +336,7 @@ Attributes allowed in the 'global' element
 | tabSetTabStripHeight | 20 | |
 | borderBarSize | 25 | |
 | borderEnableDrop | true | |
+| borderAutoSelectTab | false | whether to select new/moved tabs in border |
 | borderClassName | null | |
 | tabSetTabLocation | top | show tabs in location top or bottom |
 
@@ -402,6 +404,7 @@ Note: tabsets can be dynamically created as tabs are moved and deleted when all 
 | enableDrag | *inherited* | |
 | enableDivide | *inherited* | |
 | enableMaximize | *inherited* | |
+| autoSelectTab | *inherited* | whether to select new/moved tabs in tabset |
 | classNameTabStrip | *inherited* | |
 | classNameHeader | *inherited* | |
 | enableTabStrip | *inherited* | |
@@ -426,6 +429,7 @@ Inherited defaults will take their value from the associated global attributes (
 | children | *required* | a list of tab nodes |
 | barSize | *inherited* | |
 | enableDrop | *inherited* | |
+| autoSelectTab | *inherited* | whether to select new/moved tabs in border |
 | className | *inherited* | |
 
 
@@ -451,8 +455,8 @@ adjusting the layout easier on a small device.
 
 | Action Creator | Description  |
 | ------------- | -----|
-|	Actions.addNode(newNodeJson, toNodeId, location, index, doNotSelect?) | add a new tab node to the given tabset node, and select it unless doNotSelect is true |
-|	Actions.moveNode(fromNodeId, toNodeId, location, index, doNotSelect?) | move a tab node from its current location to the new node and location, and select it unless doNotSelect is true |
+|	Actions.addNode(newNodeJson, toNodeId, location, index, select?) | add a new tab node to the given tabset node; `select` specifies whether to select new tab, defaulting to `autoSelectTab` attribute |
+|	Actions.moveNode(fromNodeId, toNodeId, location, index, select?) | move a tab node from its current location to the new node and location; `select` specifies whether to select tab, defaulting to new tabset's `autoSelectTab` attribute |
 |	Actions.deleteTab(tabNodeId) | delete the given tab |
 |	Actions.selectTab(tabNodeId) | select the given tab |
 |	Actions.setActiveTabset(tabsetNodeId) | set the tabset as the active tabset |

--- a/README.md
+++ b/README.md
@@ -336,7 +336,8 @@ Attributes allowed in the 'global' element
 | tabSetTabStripHeight | 0 | Height of tabset tab bar in pixels, if left as 0 and fontSize prop exists then calculated from fontSize, otherwise defaults to 23|
 | borderBarSize | 0 | Size of the border bars in pixels, if left as 0 and fontSize prop exists then calculated from fontSize, otherwise defaults to 26 |
 | borderEnableDrop | true | |
-| borderAutoSelectTab | false | whether to select new/moved tabs in border |
+| borderAutoSelectTabWhenOpen | true | whether to select new/moved tabs in border when the border is already open |
+| borderAutoSelectTabWhenClosed | false | whether to select new/moved tabs in border when the border is curently closed |
 | borderClassName | null | |
 | tabSetTabLocation | top | show tabs in location top or bottom |
 
@@ -429,7 +430,8 @@ Inherited defaults will take their value from the associated global attributes (
 | children | *required* | a list of tab nodes |
 | barSize | *inherited* | |
 | enableDrop | *inherited* | |
-| autoSelectTab | *inherited* | whether to select new/moved tabs in border |
+| autoSelectTabWhenOpen | *inherited* | whether to select new/moved tabs in border when the border is already open |
+| autoSelectTabWhenClosed | *inherited* | whether to select new/moved tabs in border when the border is currently closed |
 | className | *inherited* | |
 
 

--- a/src/model/Actions.ts
+++ b/src/model/Actions.ts
@@ -26,16 +26,16 @@ class Actions {
    * @param toNodeId the new tab node will be added to the tabset with this node id
    * @param location the location where the new tab will be added, one of the DockLocation enum values.
    * @param index for docking to the center this value is the index of the tab, use -1 to add to the end.
-   * @param doNotSelect if true, skip the default behavior of selecting the new tab
-   * @returns {{type: (string|string), json: *, toNode: *, location: (*|string), index: *, doNotSelect?: boolean}}
+   * @param select (optional) whether to select the new tab, overriding autoSelectTab
+   * @returns {{type: (string|string), json: *, toNode: *, location: (*|string), index: *, select?: boolean}}
    */
-  static addNode(json: any, toNodeId: string, location: DockLocation, index: number, doNotSelect?: boolean): Action {
+  static addNode(json: any, toNodeId: string, location: DockLocation, index: number, select?: boolean): Action {
     return new Action(Actions.ADD_NODE, {
       json,
       toNode: toNodeId,
       location: location.getName(),
       index,
-      doNotSelect
+      select
     });
   }
 
@@ -45,16 +45,16 @@ class Actions {
    * @param toNodeId the id of the node to receive the moved node
    * @param location the location where the moved node will be added, one of the DockLocation enum values.
    * @param index for docking to the center this value is the index of the tab, use -1 to add to the end.
-   * @param doNotSelect if true, skip the default behavior of selecting the new tab
+   * @param select (optional) whether to select the moved tab(s) in new tabset, overriding autoSelectTab
    * @returns {{type: (string|string), fromNode: *, toNode: *, location: (*|string), index: *}}
    */
-  static moveNode(fromNodeId: string, toNodeId: string, location: DockLocation, index: number, doNotSelect?: boolean): Action {
+  static moveNode(fromNodeId: string, toNodeId: string, location: DockLocation, index: number, select?: boolean): Action {
     return new Action(Actions.MOVE_NODE, {
       fromNode: fromNodeId,
       toNode: toNodeId,
       location: location.getName(),
       index,
-      doNotSelect
+      select
     });
   }
 

--- a/src/model/Actions.ts
+++ b/src/model/Actions.ts
@@ -26,10 +26,17 @@ class Actions {
    * @param toNodeId the new tab node will be added to the tabset with this node id
    * @param location the location where the new tab will be added, one of the DockLocation enum values.
    * @param index for docking to the center this value is the index of the tab, use -1 to add to the end.
-   * @returns {{type: (string|string), json: *, toNode: *, location: (*|string), index: *}}
+   * @param doNotSelect if true, skip the default behavior of selecting the new tab
+   * @returns {{type: (string|string), json: *, toNode: *, location: (*|string), index: *, doNotSelect?: boolean}}
    */
-  static addNode(json: any, toNodeId: string, location: DockLocation, index: number): Action {
-    return new Action(Actions.ADD_NODE, { json, toNode: toNodeId, location: location.getName(), index });
+  static addNode(json: any, toNodeId: string, location: DockLocation, index: number, doNotSelect?: boolean): Action {
+    return new Action(Actions.ADD_NODE, {
+      json,
+      toNode: toNodeId,
+      location: location.getName(),
+      index,
+      doNotSelect
+    });
   }
 
   /**
@@ -38,14 +45,16 @@ class Actions {
    * @param toNodeId the id of the node to receive the moved node
    * @param location the location where the moved node will be added, one of the DockLocation enum values.
    * @param index for docking to the center this value is the index of the tab, use -1 to add to the end.
+   * @param doNotSelect if true, skip the default behavior of selecting the new tab
    * @returns {{type: (string|string), fromNode: *, toNode: *, location: (*|string), index: *}}
    */
-  static moveNode(fromNodeId: string, toNodeId: string, location: DockLocation, index: number): Action {
+  static moveNode(fromNodeId: string, toNodeId: string, location: DockLocation, index: number, doNotSelect?: boolean): Action {
     return new Action(Actions.MOVE_NODE, {
       fromNode: fromNodeId,
       toNode: toNodeId,
       location: location.getName(),
-      index
+      index,
+      doNotSelect
     });
   }
 

--- a/src/model/BorderNode.ts
+++ b/src/model/BorderNode.ts
@@ -296,7 +296,7 @@ class BorderNode extends Node implements IDropTarget {
   }
 
   /** @hidden @internal */
-  drop(dragNode: (Node & IDraggable), location: DockLocation, index: number): void {
+  drop(dragNode: (Node & IDraggable), location: DockLocation, index: number, doNotSelect: boolean): void {
     let fromIndex = 0;
     const parent: Node | undefined = dragNode.getParent();
     if (parent !== undefined) {
@@ -337,7 +337,7 @@ class BorderNode extends Node implements IDropTarget {
       this._addChild(dragNode, insertPos);
     }
 
-    if (this.getSelected() !== -1) { // already open
+    if (!doNotSelect) {
       this._setSelected(insertPos);
     }
 

--- a/src/model/BorderNode.ts
+++ b/src/model/BorderNode.ts
@@ -46,7 +46,8 @@ class BorderNode extends Node implements IDropTarget {
     attributeDefinitions.addInherited("barSize", "borderBarSize").setType(Attribute.INT).setFrom(0);
     attributeDefinitions.addInherited("enableDrop", "borderEnableDrop").setType(Attribute.BOOLEAN);
     attributeDefinitions.addInherited("className", "borderClassName").setType(Attribute.STRING);
-    attributeDefinitions.addInherited("autoSelectTab", "borderAutoSelectTab").setType(Attribute.BOOLEAN);
+    attributeDefinitions.addInherited("autoSelectTabWhenOpen", "borderAutoSelectTabWhenOpen").setType(Attribute.BOOLEAN);
+    attributeDefinitions.addInherited("autoSelectTabWhenClosed", "borderAutoSelectTabWhenClosed").setType(Attribute.BOOLEAN);
     return attributeDefinitions;
   }
 
@@ -88,8 +89,15 @@ class BorderNode extends Node implements IDropTarget {
     return this._getAttr("enableDrop") as boolean;
   }
 
-  isAutoSelectTab() {
-    return this._getAttr("autoSelectTab") as boolean;
+  isAutoSelectTab(whenOpen?: boolean) {
+    if (whenOpen == null) {
+      whenOpen = (this.getSelected() !== -1);
+    }
+    if (whenOpen) {
+      return this._getAttr("autoSelectTabWhenOpen") as boolean;
+    } else {
+      return this._getAttr("autoSelectTabWhenClosed") as boolean;
+    }
   }
 
   getClassName() {

--- a/src/model/BorderNode.ts
+++ b/src/model/BorderNode.ts
@@ -46,6 +46,7 @@ class BorderNode extends Node implements IDropTarget {
     attributeDefinitions.addInherited("barSize", "borderBarSize").setType(Attribute.INT).setFrom(0);
     attributeDefinitions.addInherited("enableDrop", "borderEnableDrop").setType(Attribute.BOOLEAN);
     attributeDefinitions.addInherited("className", "borderClassName").setType(Attribute.STRING);
+    attributeDefinitions.addInherited("autoSelectTab", "borderAutoSelectTab").setType(Attribute.BOOLEAN);
     return attributeDefinitions;
   }
 
@@ -85,6 +86,10 @@ class BorderNode extends Node implements IDropTarget {
 
   isEnableDrop() {
     return this._getAttr("enableDrop") as boolean;
+  }
+
+  isAutoSelectTab() {
+    return this._getAttr("autoSelectTab") as boolean;
   }
 
   getClassName() {
@@ -296,7 +301,7 @@ class BorderNode extends Node implements IDropTarget {
   }
 
   /** @hidden @internal */
-  drop(dragNode: (Node & IDraggable), location: DockLocation, index: number, doNotSelect: boolean): void {
+  drop(dragNode: (Node & IDraggable), location: DockLocation, index: number, select?: boolean): void {
     let fromIndex = 0;
     const parent: Node | undefined = dragNode.getParent();
     if (parent !== undefined) {
@@ -337,7 +342,7 @@ class BorderNode extends Node implements IDropTarget {
       this._addChild(dragNode, insertPos);
     }
 
-    if (!doNotSelect) {
+    if (select || (select !== false && this.isAutoSelectTab())) {
       this._setSelected(insertPos);
     }
 

--- a/src/model/IDropTarget.ts
+++ b/src/model/IDropTarget.ts
@@ -7,7 +7,7 @@ export default interface IDropTarget {
   /** @hidden @internal */
   canDrop(dragNode: (Node & IDraggable), x: number, y: number): DropInfo | undefined;
   /** @hidden @internal */
-  drop(dragNode: (Node & IDraggable), location: DockLocation, index: number): void;
+  drop(dragNode: (Node & IDraggable), location: DockLocation, index: number, doNotSelect: boolean): void;
   /** @hidden @internal */
   isEnableDrop(): boolean;
 

--- a/src/model/IDropTarget.ts
+++ b/src/model/IDropTarget.ts
@@ -7,7 +7,7 @@ export default interface IDropTarget {
   /** @hidden @internal */
   canDrop(dragNode: (Node & IDraggable), x: number, y: number): DropInfo | undefined;
   /** @hidden @internal */
-  drop(dragNode: (Node & IDraggable), location: DockLocation, index: number, doNotSelect: boolean): void;
+  drop(dragNode: (Node & IDraggable), location: DockLocation, index: number, select?: boolean): void;
   /** @hidden @internal */
   isEnableDrop(): boolean;
 

--- a/src/model/Model.ts
+++ b/src/model/Model.ts
@@ -209,7 +209,7 @@ class Model {
           const newNode = new TabNode(this, action.data.json, true);
           const toNode = this._idMap[action.data.toNode] as (Node & IDraggable);
           if (toNode instanceof TabSetNode || toNode instanceof BorderNode || toNode instanceof RowNode) {
-            toNode.drop(newNode, DockLocation.getByName(action.data.location), action.data.index);
+            toNode.drop(newNode, DockLocation.getByName(action.data.location), action.data.index, action.data.doNotSelect || false);
           }
           break;
         }
@@ -219,7 +219,7 @@ class Model {
           if (fromNode instanceof TabNode || fromNode instanceof TabSetNode) {
             const toNode = this._idMap[action.data.toNode] as (Node & IDropTarget);
             if (toNode instanceof TabSetNode || toNode instanceof BorderNode || toNode instanceof RowNode) {
-              toNode.drop(fromNode, DockLocation.getByName(action.data.location), action.data.index);
+              toNode.drop(fromNode, DockLocation.getByName(action.data.location), action.data.index, action.data.doNotSelect || false);
             }
           }
           break;

--- a/src/model/Model.ts
+++ b/src/model/Model.ts
@@ -65,6 +65,7 @@ class Model {
     attributeDefinitions.add("tabSetEnableDrag", true).setType(Attribute.BOOLEAN);
     attributeDefinitions.add("tabSetEnableDivide", true).setType(Attribute.BOOLEAN);
     attributeDefinitions.add("tabSetEnableMaximize", true).setType(Attribute.BOOLEAN);
+    attributeDefinitions.add("tabSetAutoSelectTab", true).setType(Attribute.BOOLEAN);
     attributeDefinitions.add("tabSetClassNameTabStrip", undefined).setType(Attribute.STRING);
     attributeDefinitions.add("tabSetClassNameHeader", undefined).setType(Attribute.STRING);
     attributeDefinitions.add("tabSetEnableTabStrip", true).setType(Attribute.BOOLEAN);
@@ -74,8 +75,10 @@ class Model {
     attributeDefinitions.add("tabSetBorderInsets", { top: 0, right: 0, bottom: 0, left: 0 }).setType(Attribute.JSON);
     attributeDefinitions.add("tabSetTabLocation", "top").setType(Attribute.STRING);
 
+    // border
     attributeDefinitions.add("borderBarSize", 26);
     attributeDefinitions.add("borderEnableDrop", true).setType(Attribute.BOOLEAN);
+    attributeDefinitions.add("borderAutoSelectTab", false).setType(Attribute.BOOLEAN);
     attributeDefinitions.add("borderClassName", undefined).setType(Attribute.STRING);
     return attributeDefinitions;
   }
@@ -209,7 +212,7 @@ class Model {
           const newNode = new TabNode(this, action.data.json, true);
           const toNode = this._idMap[action.data.toNode] as (Node & IDraggable);
           if (toNode instanceof TabSetNode || toNode instanceof BorderNode || toNode instanceof RowNode) {
-            toNode.drop(newNode, DockLocation.getByName(action.data.location), action.data.index, action.data.doNotSelect || false);
+            toNode.drop(newNode, DockLocation.getByName(action.data.location), action.data.index, action.data.select);
           }
           break;
         }
@@ -219,7 +222,7 @@ class Model {
           if (fromNode instanceof TabNode || fromNode instanceof TabSetNode) {
             const toNode = this._idMap[action.data.toNode] as (Node & IDropTarget);
             if (toNode instanceof TabSetNode || toNode instanceof BorderNode || toNode instanceof RowNode) {
-              toNode.drop(fromNode, DockLocation.getByName(action.data.location), action.data.index, action.data.doNotSelect || false);
+              toNode.drop(fromNode, DockLocation.getByName(action.data.location), action.data.index, action.data.select);
             }
           }
           break;

--- a/src/model/Model.ts
+++ b/src/model/Model.ts
@@ -78,7 +78,8 @@ class Model {
     // border
     attributeDefinitions.add("borderBarSize", 0).setType(Attribute.INT).setFrom(0);
     attributeDefinitions.add("borderEnableDrop", true).setType(Attribute.BOOLEAN);
-    attributeDefinitions.add("borderAutoSelectTab", false).setType(Attribute.BOOLEAN);
+    attributeDefinitions.add("borderAutoSelectTabWhenOpen", true).setType(Attribute.BOOLEAN);
+    attributeDefinitions.add("borderAutoSelectTabWhenClosed", false).setType(Attribute.BOOLEAN);
     attributeDefinitions.add("borderClassName", undefined).setType(Attribute.STRING);
     return attributeDefinitions;
   }

--- a/src/model/TabSetNode.ts
+++ b/src/model/TabSetNode.ts
@@ -271,7 +271,7 @@ class TabSetNode extends Node implements IDraggable, IDropTarget {
   }
 
   /** @hidden @internal */
-  drop(dragNode: (Node & IDraggable), location: DockLocation, index: number) {
+  drop(dragNode: (Node & IDraggable), location: DockLocation, index: number, doNotSelect: boolean) {
     const dockLocation = location;
 
     if (this === dragNode) { // tabset drop into itself
@@ -322,7 +322,9 @@ class TabSetNode extends Node implements IDraggable, IDropTarget {
 
       if (dragNode.getType() === TabNode.TYPE) {
         this._addChild(dragNode, insertPos);
-        this._setSelected(insertPos);
+        if (!doNotSelect) {
+          this._setSelected(insertPos);
+        }
         // console.log("added child at : " + insertPos);
       }
       else {

--- a/src/model/TabSetNode.ts
+++ b/src/model/TabSetNode.ts
@@ -66,6 +66,7 @@ class TabSetNode extends Node implements IDraggable, IDropTarget {
     attributeDefinitions.addInherited("headerHeight", "tabSetHeaderHeight");
     attributeDefinitions.addInherited("tabStripHeight", "tabSetTabStripHeight");
     attributeDefinitions.addInherited("tabLocation", "tabSetTabLocation");
+    attributeDefinitions.addInherited("autoSelectTab", "tabSetAutoSelectTab").setType(Attribute.BOOLEAN);
     return attributeDefinitions;
   }
 
@@ -144,6 +145,10 @@ class TabSetNode extends Node implements IDraggable, IDropTarget {
 
   isEnableTabStrip() {
     return this._getAttr("enableTabStrip") as boolean;
+  }
+
+  isAutoSelectTab() {
+    return this._getAttr("autoSelectTab") as boolean;
   }
 
   getClassNameTabStrip() {
@@ -271,7 +276,7 @@ class TabSetNode extends Node implements IDraggable, IDropTarget {
   }
 
   /** @hidden @internal */
-  drop(dragNode: (Node & IDraggable), location: DockLocation, index: number, doNotSelect: boolean) {
+  drop(dragNode: (Node & IDraggable), location: DockLocation, index: number, select?: boolean) {
     const dockLocation = location;
 
     if (this === dragNode) { // tabset drop into itself
@@ -322,7 +327,7 @@ class TabSetNode extends Node implements IDraggable, IDropTarget {
 
       if (dragNode.getType() === TabNode.TYPE) {
         this._addChild(dragNode, insertPos);
-        if (!doNotSelect) {
+        if (select || (select !== false && this.isAutoSelectTab())) {
           this._setSelected(insertPos);
         }
         // console.log("added child at : " + insertPos);

--- a/style/dark.css
+++ b/style/dark.css
@@ -59,14 +59,14 @@
   padding: 10px;
   word-wrap: break-word;
   font-size: 14px;
-  font-family: "Roboto", Arial, sans-serif;
+  font-family: Roboto, Arial, sans-serif;
 }
 .flexlayout__tabset {
   overflow: hidden;
   background-color: #121212;
   box-sizing: border-box;
   font-size: 14px;
-  font-family: "Roboto", Arial, sans-serif;
+  font-family: Roboto, Arial, sans-serif;
 }
 .flexlayout__tabset_header {
   position: absolute;
@@ -211,7 +211,7 @@
 }
 .flexlayout__popup_menu {
   font-size: 14px;
-  font-family: "Roboto", Arial, sans-serif;
+  font-family: Roboto, Arial, sans-serif;
 }
 .flexlayout__popup_menu_item {
   padding: 2px 10px 2px 10px;
@@ -234,7 +234,7 @@
   overflow: hidden;
   display: flex;
   font-size: 14px;
-  font-family: "Roboto", Arial, sans-serif;
+  font-family: Roboto, Arial, sans-serif;
   border-bottom: 1px solid #262626;
   align-items: center;
 }
@@ -244,7 +244,7 @@
   overflow: hidden;
   display: flex;
   font-size: 14px;
-  font-family: "Roboto", Arial, sans-serif;
+  font-family: Roboto, Arial, sans-serif;
   border-top: 1px solid #262626;
   align-items: center;
 }
@@ -254,7 +254,7 @@
   overflow: hidden;
   display: flex;
   font-size: 14px;
-  font-family: "Roboto", Arial, sans-serif;
+  font-family: Roboto, Arial, sans-serif;
   border-right: 1px solid #262626;
   align-content: center;
 }
@@ -264,7 +264,7 @@
   overflow: hidden;
   display: flex;
   font-size: 14px;
-  font-family: "Roboto", Arial, sans-serif;
+  font-family: Roboto, Arial, sans-serif;
   border-left: 1px solid #262626;
   align-content: center;
 }

--- a/style/light.css
+++ b/style/light.css
@@ -59,14 +59,14 @@
   padding: 10px;
   word-wrap: break-word;
   font-size: 14px;
-  font-family: "Roboto", Arial, sans-serif;
+  font-family: Roboto, Arial, sans-serif;
 }
 .flexlayout__tabset {
   overflow: hidden;
   background-color: #f7f7f7;
   box-sizing: border-box;
   font-size: 14px;
-  font-family: "Roboto", Arial, sans-serif;
+  font-family: Roboto, Arial, sans-serif;
 }
 .flexlayout__tabset_header {
   position: absolute;
@@ -211,7 +211,7 @@
 }
 .flexlayout__popup_menu {
   font-size: 14px;
-  font-family: "Roboto", Arial, sans-serif;
+  font-family: Roboto, Arial, sans-serif;
 }
 .flexlayout__popup_menu_item {
   padding: 2px 10px 2px 10px;
@@ -234,7 +234,7 @@
   overflow: hidden;
   display: flex;
   font-size: 14px;
-  font-family: "Roboto", Arial, sans-serif;
+  font-family: Roboto, Arial, sans-serif;
   border-bottom: 1px solid #d9d9d9;
   align-items: center;
 }
@@ -244,7 +244,7 @@
   overflow: hidden;
   display: flex;
   font-size: 14px;
-  font-family: "Roboto", Arial, sans-serif;
+  font-family: Roboto, Arial, sans-serif;
   border-top: 1px solid #d9d9d9;
   align-items: center;
 }
@@ -254,7 +254,7 @@
   overflow: hidden;
   display: flex;
   font-size: 14px;
-  font-family: "Roboto", Arial, sans-serif;
+  font-family: Roboto, Arial, sans-serif;
   border-right: 1px solid #d9d9d9;
   align-content: center;
 }
@@ -264,7 +264,7 @@
   overflow: hidden;
   display: flex;
   font-size: 14px;
-  font-family: "Roboto", Arial, sans-serif;
+  font-family: Roboto, Arial, sans-serif;
   border-left: 1px solid #d9d9d9;
   align-content: center;
 }


### PR DESCRIPTION
Fix #137. Summary of changes:
* `Actions.addNode` and `Actions.moveNode` support an additional optional boolean argument `doNotSelect`. This gets passed through to `drop()`.
* If the argument is false, the added or moved node is selected. This is as it was before for TabSets (but see below for BorderNodes)
* If the argument is true, the node isn't selected.
* Breaking change: dropping onto a BorderNode now automatically selects the tab, unless `doNotSelect` is true. The old behavior was to select the tab unless another tab was already selected for that border.  I'd actually encountered this before, and it seems inconsistent and confusing.  Now it's consistent with TabSet.