### PR TITLE
Select adjacent tab when dragging selected tab out of TabSet/Border

### DIFF
--- a/src/model/TabSetNode.ts
+++ b/src/model/TabSetNode.ts
@@ -341,25 +341,23 @@ class TabSetNode extends Node implements IDraggable, IDropTarget {
     }
 
     // for the tabset/border being removed from set the selected index
-    if (dragParent !== undefined) {
-      if (dragParent.getType() === TabSetNode.TYPE) {
-        dragParent._setSelected(0);
-      }
-      else if (dragParent.getType() === BorderNode.TYPE) {
-        if (dragParent.getSelected() !== -1) {
-          if (fromIndex === dragParent.getSelected() && dragParent.getChildren().length > 0) {
-            dragParent._setSelected(0);
-          }
-          else if (fromIndex < dragParent.getSelected()) {
-            dragParent._setSelected(dragParent.getSelected() - 1);
-          }
-          else if (fromIndex > dragParent.getSelected()) {
-            // leave selected index as is
-          }
-          else {
-            dragParent._setSelected(-1);
-          }
+    if (dragParent !== undefined && dragParent.getSelected() !== -1) {
+      if (fromIndex === dragParent.getSelected() && dragParent.getChildren().length > 0) {
+        if (fromIndex >= dragParent.getChildren().length) {
+          // removed last tab; select new last tab
+          dragParent._setSelected(dragParent.getChildren().length - 1);
+        } else {
+          // leave selected index as is, selecting next tab after this one
         }
+      }
+      else if (fromIndex < dragParent.getSelected()) {
+        dragParent._setSelected(dragParent.getSelected() - 1);
+      }
+      else if (fromIndex > dragParent.getSelected()) {
+        // leave selected index as is
+      }
+      else {
+        dragParent._setSelected(-1);
       }
     }
 


### PR DESCRIPTION
Example of *current* behavior:
* Consider a TabSet with three tabs, call them 1, 2, 3.
* If you drag tab 2 or 3 out of the TabSet to another location, then FlexLayout currently *always selects tab 1*.
* This leads to some pretty weird behavior. For example:
  * If tab 2 is selected, and you drag tab 3 out of the TabSet, then tab 2 *deselects* and tab 1 gets selected! (This is particularly confusing/jarring.)
  * If tab 3 is selected, and you drag tab 3 out of the TabSet, then tab 1 gets selected, even though tab 2 is closer. (This isn't a huge deal, but feels counterintuitive.)

This PR implements Chrome's behavior:
* If you drag a tab out of a TabSet or a Border, and it wasn't selected, then nothing changes. (This was already implemented for Border, but not TabSet. In particular, I preserved the existing behavior that, if you drag a tab out of a Border with nothing selected, then nothing remains selected.)
* If you drag a tab out of a TabSet or a Border, and it was selected, then the next tab gets selected (i.e. don't change the selected index), unless you dragged out the last tab, in which case the previous tab (now the last tab) gets selected.

This changes existing behavior but, I believe, to far more intuitive behavior. Arguably the existing behavior was a bug. But let me know what you think!