### PR TITLE
Intercept mousedown and touchstart events in all buttons

### DIFF
--- a/src/view/BorderTabSet.tsx
+++ b/src/view/BorderTabSet.tsx
@@ -192,7 +192,10 @@ export const BorderTabSet = (props: IBorderTabSetProps) => {
                                          cm("flexlayout__border_toolbar_button") + " " + 
                                          cm("flexlayout__border_toolbar_button-float")
                                         }
-                                     onClick={onFloatTab}/>);
+                                     onClick={onFloatTab}
+                                     onMouseDown={onInterceptMouseDown}
+                                     onTouchStart={onInterceptMouseDown}
+                             />);
             }
         }
         toolbar = <div
@@ -208,9 +211,9 @@ export const BorderTabSet = (props: IBorderTabSetProps) => {
     if (showOverflow.current === true && hiddenTabs.length > 0) {
         const overflowButton = (<button key="overflowbutton" ref={overflowbuttonRef}
                                         className={cm("flexlayout__border_button_overflow_" + border.getLocation().getName())}
-                                        onTouchStart={onInterceptMouseDown}
                                         onClick={() => onOverflowClick()}
                                         onMouseDown={onInterceptMouseDown}
+                                        onTouchStart={onInterceptMouseDown}
         >{hiddenTabs.length}</button>);
         tabs.push(overflowButton);
     }

--- a/src/view/TabSet.tsx
+++ b/src/view/TabSet.tsx
@@ -206,6 +206,8 @@ export const TabSet = (props: ITabSetProps) => {
                                     cm("flexlayout__tab_toolbar_button-float")
                                 }
                                  onClick={onFloatTab}
+                                 onMouseDown={onInterceptMouseDown}
+                                 onTouchStart={onInterceptMouseDown}
             >{icons?.popout}</button>);
         }
         if (node.isEnableMaximize()) {
@@ -218,6 +220,8 @@ export const TabSet = (props: ITabSetProps) => {
                                     cm("flexlayout__tab_toolbar_button-" + (node.isMaximized() ? "max" : "min"))
                                 }
                                  onClick={onMaximizeToggle}
+                                 onMouseDown={onInterceptMouseDown}
+                                 onTouchStart={onInterceptMouseDown}
             >{node.isMaximized() ? icons?.restore : icons?.maximize}</button>);
         }
 
@@ -230,9 +234,9 @@ export const TabSet = (props: ITabSetProps) => {
     if (showOverflow.current === true && hiddenTabs.length > 0) {
         tabs.push(<button key="overflowbutton" ref={overflowbuttonRef}
                           className={cm("flexlayout__tab_button_overflow")}
-                          onTouchStart={onInterceptMouseDown}
                           onClick={onOverflowClick}
                           onMouseDown={onInterceptMouseDown}
+                          onTouchStart={onInterceptMouseDown}
         >{icons?.more}{hiddenTabs.length}</button>);
     }
 


### PR DESCRIPTION
Buttons in tabs and tabsets and borders need to `stopPropagation` in `onMouseDown` and `onTouchStart`, to avoid the drag behavior of the rest of the header.  But a few buttons were missing this behavior.  For example, the maximize button currently doesn't work on Chrome on Android.  With this fix, the button works.