### PR TITLE
update from react 16.9.x to 17.0.1 causes issue when removing flexlayout from the DOM

### DIFF
--- a/src/view/TabOverflowHook.tsx
+++ b/src/view/TabOverflowHook.tsx
@@ -25,9 +25,10 @@ export const useTabOverflow = (node: TabSetNode | BorderNode, orientation: Orien
     });
 
     React.useEffect(() => {
-        selfRef.current!.addEventListener("wheel", onWheel);
+        const instance = selfRef.current!
+        instance.addEventListener("wheel", onWheel);
         return () => {
-            selfRef.current!.removeEventListener("wheel", onWheel);
+            instance.removeEventListener("wheel", onWheel);
         };
     }, []);
 


### PR DESCRIPTION
update from react 16.9.x to 17.0.1 causes issue when removing flexlayout from the DOM

TabOverflowHook.tsx:30 Uncaught TypeError: Cannot read property 'removeEventListener' of null
    at TabOverflowHook.tsx:30
    at HTMLUnknownElement.callCallback (react-dom.development.js:3945)