### PR TITLE
Tweak border button background colors

### DIFF
--- a/style/dark.scss
+++ b/style/dark.scss
@@ -74,12 +74,13 @@ $font-family: Roboto, Arial, sans-serif !default;
 }
 
 @mixin border_mixin {
-    background-color: $color_2;
+    background-color: $color_1;
 }
 
 @mixin border_button_mixin {
     box-shadow: inset 0 0 5px rgba(0, 0, 0, .15);
     border-radius: 3px;
+    background-color: $color_2;
 }
 
 @mixin border_button_selected_mixin {

--- a/style/gray.scss
+++ b/style/gray.scss
@@ -75,12 +75,13 @@ $font-family: Roboto, Arial, sans-serif !default;
 
 
 @mixin border_mixin {
-    background-color: $color_2;
+    background-color: $color_1;
 }
 
 @mixin border_button_mixin {
     box-shadow: inset 0 0 5px rgba(0, 0, 0, .15);
     border-radius: 3px;
+    background-color: $color_2;
 }
 
 @mixin border_button_selected_mixin {

--- a/style/light.scss
+++ b/style/light.scss
@@ -61,7 +61,7 @@ $font-family: Roboto, Arial, sans-serif !default;
 }
 
 @mixin border_button_mixin {
-    background-color: $color_3;
+    background-color: $color_2;
 }
 
 @mixin border_button_selected_mixin {


### PR DESCRIPTION
This PR makes small tweaks to the default styles, achieving the following goals:
1. In dark mode, distinguish border background color from tab color.  (A recent update made them the same, which seems inconsistent and hard to see.)
2. Distinguish selected border tab with a different background color.  (This is new; I think it makes it pop slightly better, but isn't a big deal.)
3. `light.scss` specifies `background-color` if and only if `dark.scss` specifies `background-color`.  This is useful for including both sets of CSS rules, under a custom root class that allows toggling between light and dark mode.  ([Example](https://github.com/edemaine/comingle/blob/master/client/FlexLayout.sass))

Happy to tweak the specific color choices, or discuss whether these are reasonable objectives.