### PR TITLE
Drag external objects onto layout to make tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ The `<Layout>` component renders the tabsets and splitters, it takes the followi
 | onRenderTab     | optional          | function called when rendering a tab, allows leading (icon), content section, buttons and name used in overflow menu to be customized |
 | onRenderTabSet  | optional          | function called when rendering a tabset, allows header and buttons to be customized |
 | onModelChange   | optional          | function called when model has changed |
+| onExternalDrag  | optional          | function called when an external object (not a tab) gets dragged onto the layout, which should return either `undefined` to reject the drag/drop or an object with keys `dragText`, `json`, and optionally `onDrop` to create a tab via drag (similar to a call to `addTabToTabSet`) |
 | classNameMapper | optional          | function called with default css class name, return value is class name that will be used. Mainly for use with css modules.|
 | i18nMapper      | optional          | function called for each I18nLabel to allow user translation, currently used for tab and tabset move messages, return undefined to use default values |
 | supportsPopout  | optional          | if left undefined will do simple check based on userAgent |

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The `<Layout>` component renders the tabsets and splitters, it takes the followi
 | onRenderTab     | optional          | function called when rendering a tab, allows leading (icon), content section, buttons and name used in overflow menu to be customized |
 | onRenderTabSet  | optional          | function called when rendering a tabset, allows header and buttons to be customized |
 | onModelChange   | optional          | function called when model has changed |
-| onExternalDrag  | optional          | function called when an external object (not a tab) gets dragged onto the layout, with a single `dragenter` argument. Should return either `undefined` to reject the drag/drop or an object with keys `dragText`, `json`, and optionally `onDrop` to create a tab via drag (similar to a call to `addTabToTabSet`). Function `onDrop` is passed the `drop` event unless the drag was canceled. |
+| onExternalDrag  | optional          | function called when an external object (not a tab) gets dragged onto the layout, with a single `dragenter` argument. Should return either `undefined` to reject the drag/drop or an object with keys `dragText`, `json`, and optionally `onDrop`, to create a tab via drag (similar to a call to `addTabToTabSet`). Function `onDrop` is passed the added tab `Node` and the `drop` `DragEvent`, unless the drag was canceled. |
 | classNameMapper | optional          | function called with default css class name, return value is class name that will be used. Mainly for use with css modules.|
 | i18nMapper      | optional          | function called for each I18nLabel to allow user translation, currently used for tab and tabset move messages, return undefined to use default values |
 | supportsPopout  | optional          | if left undefined will do simple check based on userAgent |
@@ -455,7 +455,7 @@ generators (typically accessed as `FlexLayout.Actions.<actionName>`):
 
 | Action Creator | Description  |
 | ------------- | -----|
-|	Actions.addNode(newNodeJson, toNodeId, location, index, select?) | add a new tab node to the given tabset node; `select` specifies whether to select new tab, defaulting to `autoSelectTab` attribute |
+|	Actions.addNode(newNodeJson, toNodeId, location, index, select?) | add a new tab node to the given tabset node; `select` specifies whether to select new tab, defaulting to `autoSelectTab` attribute; returns the created `Node` |
 |	Actions.moveNode(fromNodeId, toNodeId, location, index, select?) | move a tab node from its current location to the new node and location; `select` specifies whether to select tab, defaulting to new tabset's `autoSelectTab` attribute |
 |	Actions.deleteTab(tabNodeId) | delete the given tab |
 |	Actions.renameTab(tabNodeId, newName) | rename the given tab |
@@ -482,13 +482,15 @@ model.doAction(FlexLayout.Actions.updateModelAttributes({
 The above example would increase the size of the splitters, tabset headers and tabs, this could be used to make
 adjusting the layout easier on a small device.
 
-```
+```js
 model.doAction(FlexLayout.Actions.addNode(
     {type:"tab", component:"grid", name:"a grid", id:"5"},
     "1", FlexLayout.DockLocation.CENTER, 0));
 ```
+
 This example adds a new grid component to the center of tabset with id "1" and at the 0'th tab position (use value -1 to add to the end of the tabs).
-Note: you can get the id of a node using the method `node.getId()`.
+Note: you can get the id of a node (e.g., the node returned by the `addNode`
+action) using the method `node.getId()`.
 If an id wasn't assigned when the node was created, then one will be created for you of the form `#<next available id>` (e.g. `#1`, `#2`, ...).
 
 
@@ -508,7 +510,7 @@ This would add a new grid component to the tabset with id "NAVIGATION" (where th
 | ------------- | -----|
 | addTabToTabSet(tabsetId, json) | adds a new tab to the tabset with the given Id |
 | addTabToActiveTabSet(json) | adds a new tab to the active tabset |
-| addTabWithDragAndDrop(dragText, json, onDrop) | adds a new tab by dragging a marker to the required location, the drag starts immediately |
+| addTabWithDragAndDrop(dragText, json, onDrop) | adds a new tab by dragging a marker to the required location, with the drag starting immediately; on success, `onDrop` is passed the created tab `Node`; on cancel, no arguments are passed |
 | addTabWithDragAndDropIndirect(dragText, json, onDrop) | adds a new tab by dragging a marker to the required location, the marker is shown and must be clicked on to start dragging |
 
 ## Tab Node Events

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The `<Layout>` component renders the tabsets and splitters, it takes the followi
 | onRenderTab     | optional          | function called when rendering a tab, allows leading (icon), content section, buttons and name used in overflow menu to be customized |
 | onRenderTabSet  | optional          | function called when rendering a tabset, allows header and buttons to be customized |
 | onModelChange   | optional          | function called when model has changed |
-| onExternalDrag  | optional          | function called when an external object (not a tab) gets dragged onto the layout, which should return either `undefined` to reject the drag/drop or an object with keys `dragText`, `json`, and optionally `onDrop` to create a tab via drag (similar to a call to `addTabToTabSet`) |
+| onExternalDrag  | optional          | function called when an external object (not a tab) gets dragged onto the layout, with a single `dragenter` argument. Should return either `undefined` to reject the drag/drop or an object with keys `dragText`, `json`, and optionally `onDrop` to create a tab via drag (similar to a call to `addTabToTabSet`). Function `onDrop` is passed the `drop` event unless the drag was canceled. |
 | classNameMapper | optional          | function called with default css class name, return value is class name that will be used. Mainly for use with css modules.|
 | i18nMapper      | optional          | function called for each I18nLabel to allow user translation, currently used for tab and tabset move messages, return undefined to use default values |
 | supportsPopout  | optional          | if left undefined will do simple check based on userAgent |

--- a/src/model/Model.ts
+++ b/src/model/Model.ts
@@ -215,8 +215,10 @@ class Model {
      * Update the node tree by performing the given action,
      * Actions should be generated via static methods on the Actions class
      * @param action the action to perform
+     * @returns added Node for Actions.addNode; undefined otherwise
      */
-    doAction(action: Action) {
+    doAction(action: Action): Node | undefined {
+        let returnVal = undefined;
         // console.log(action);
         switch (action.type) {
             case Actions.ADD_NODE: {
@@ -224,6 +226,7 @@ class Model {
                 const toNode = this._idMap[action.data.toNode] as Node & IDraggable;
                 if (toNode instanceof TabSetNode || toNode instanceof BorderNode || toNode instanceof RowNode) {
                     toNode.drop(newNode, DockLocation.getByName(action.data.location), action.data.index, action.data.select);
+                    returnVal = newNode;
                 }
                 break;
             }
@@ -343,6 +346,8 @@ class Model {
         if (this._changeListener !== undefined) {
             this._changeListener();
         }
+
+        return returnVal;
     }
 
     /** @hidden @internal */

--- a/src/view/Layout.tsx
+++ b/src/view/Layout.tsx
@@ -58,7 +58,7 @@ export interface ILayoutProps {
     onExternalDrag?: (event: React.DragEvent<HTMLDivElement>) => undefined | {
       dragText: string,
       json: any,
-      onDrop?: (event?: Event) => void
+      onDrop?: (node?: Node, event?: Event) => void
     };
     classNameMapper?: (defaultClassName: string) => string;
     i18nMapper?: (id: I18nLabel, param?: string) => string | undefined;
@@ -90,7 +90,7 @@ export interface ILayoutCallbacks {
     isSupportsPopout(): boolean;
     getCurrentDocument(): HTMLDocument | undefined;
     getClassName(defaultClassName: string): string;
-    doAction(action: Action): void;
+    doAction(action: Action): Node | undefined;
     getDomRect(): any;
     getRootDiv(): HTMLDivElement;
     dragStart(
@@ -179,7 +179,7 @@ export class Layout extends React.Component<ILayoutProps, ILayoutState> {
     /** @hidden @internal */
     private edgeTopDiv?: HTMLDivElement;
     /** @hidden @internal */
-    private fnNewNodeDropped?: (event?: Event) => void;
+    private fnNewNodeDropped?: (node?: Node, event?: Event) => void;
     /** @hidden @internal */
     private currentDocument?: HTMLDocument;
     /** @hidden @internal */
@@ -239,14 +239,15 @@ export class Layout extends React.Component<ILayoutProps, ILayoutState> {
     };
 
     /** @hidden @internal */
-    doAction(action: Action): void {
+    doAction(action: Action): Node | undefined {
         if (this.props.onAction !== undefined) {
             const outcome = this.props.onAction(action);
             if (outcome !== undefined) {
-                this.props.model.doAction(outcome);
+                return this.props.model.doAction(outcome);
             }
+            return undefined;
         } else {
-            this.props.model.doAction(action);
+            return this.props.model.doAction(action);
         }
     }
 
@@ -573,7 +574,7 @@ export class Layout extends React.Component<ILayoutProps, ILayoutState> {
      * @param json the json for the new tab node
      * @param onDrop a callback to call when the drag is complete
      */
-    addTabWithDragAndDrop(dragText: string, json: any, onDrop?: (event?: Event) => void) {
+    addTabWithDragAndDrop(dragText: string, json: any, onDrop?: (node?: Node, event?: Event) => void) {
         this.fnNewNodeDropped = onDrop;
         this.newTabJson = json;
         this.dragStart(undefined, dragText, TabNode._fromJson(json, this.props.model, false), true, undefined, undefined);
@@ -730,10 +731,10 @@ export class Layout extends React.Component<ILayoutProps, ILayoutState> {
 
         if (this.dropInfo) {
             if (this.newTabJson !== undefined) {
-                this.doAction(Actions.addNode(this.newTabJson, this.dropInfo.node.getId(), this.dropInfo.location, this.dropInfo.index));
+                const newNode = this.doAction(Actions.addNode(this.newTabJson, this.dropInfo.node.getId(), this.dropInfo.location, this.dropInfo.index));
 
                 if (this.fnNewNodeDropped != null) {
-                    this.fnNewNodeDropped(event);
+                    this.fnNewNodeDropped(newNode, event);
                     this.fnNewNodeDropped = undefined;
                 }
                 this.newTabJson = undefined;

--- a/src/view/Layout.tsx
+++ b/src/view/Layout.tsx
@@ -58,7 +58,7 @@ export interface ILayoutProps {
     onExternalDrag?: (event: React.DragEvent<HTMLDivElement>) => undefined | {
       dragText: string,
       json: any,
-      onDrop?: () => void
+      onDrop?: (event?: Event) => void
     };
     classNameMapper?: (defaultClassName: string) => string;
     i18nMapper?: (id: I18nLabel, param?: string) => string | undefined;
@@ -179,7 +179,7 @@ export class Layout extends React.Component<ILayoutProps, ILayoutState> {
     /** @hidden @internal */
     private edgeTopDiv?: HTMLDivElement;
     /** @hidden @internal */
-    private fnNewNodeDropped?: () => void;
+    private fnNewNodeDropped?: (event?: Event) => void;
     /** @hidden @internal */
     private currentDocument?: HTMLDocument;
     /** @hidden @internal */
@@ -573,7 +573,7 @@ export class Layout extends React.Component<ILayoutProps, ILayoutState> {
      * @param json the json for the new tab node
      * @param onDrop a callback to call when the drag is complete
      */
-    addTabWithDragAndDrop(dragText: string, json: any, onDrop?: () => void) {
+    addTabWithDragAndDrop(dragText: string, json: any, onDrop?: (event?: Event) => void) {
         this.fnNewNodeDropped = onDrop;
         this.newTabJson = json;
         this.dragStart(undefined, dragText, TabNode._fromJson(json, this.props.model, false), true, undefined, undefined);
@@ -720,7 +720,7 @@ export class Layout extends React.Component<ILayoutProps, ILayoutState> {
     };
 
     /** @hidden @internal */
-    onDragEnd = () => {
+    onDragEnd = (event: Event) => {
         const rootdiv = this.selfRef.current!;
         rootdiv.removeChild(this.outlineDiv!);
         rootdiv.removeChild(this.dragDiv!);
@@ -733,7 +733,7 @@ export class Layout extends React.Component<ILayoutProps, ILayoutState> {
                 this.doAction(Actions.addNode(this.newTabJson, this.dropInfo.node.getId(), this.dropInfo.location, this.dropInfo.index));
 
                 if (this.fnNewNodeDropped != null) {
-                    this.fnNewNodeDropped();
+                    this.fnNewNodeDropped(event);
                     this.fnNewNodeDropped = undefined;
                 }
                 this.newTabJson = undefined;


### PR DESCRIPTION
This PR adds a configuration option `onExternalDrag` to allow the layout to handle drags from outside the layout (e.g. files or links or even draggable objects from other parts of the app outside the layout) that cause the creation of tabs.  In [my app](https://github.com/edemaine/comingle), I want to be able to drag URLs from e.g. another browser window in order to create a tab that iframes that URL.

Most of the changes are local to DragDrop, which has extra event handlers for the many various drag/drop events (and the usual [counter workaround](https://www.smashingmagazine.com/2020/02/html-drag-drop-api-react/) to handle dragging entering/leaving various elements).  The main other change is that Layout needs to listen to `dragenter` as yet another way to start a new drag operation.

I hope you like it!  Let me know if you want it tweaked in any way.

(This is the main feature addition that led me down the path to the other PR and issue.)