### PR TITLE
External drag, with pointerEvents enabled

### DIFF
--- a/src/DragDrop.ts
+++ b/src/DragDrop.ts
@@ -72,13 +72,6 @@ class DragDrop {
         this._clickY = 0;
     }
 
-    // allow pointer events to be disabled on glass pane, needed for external drag
-    // in other cases pointer events must be enabled to allow dragging over iframes 
-    // re-enabled in hideGlass()
-    disableGlassPointerEvents() {
-        this._glass!.style.pointerEvents = "none";
-    }
-
     // if you add the glass pane then you should remove it
     addGlass(fCancel: ((wasDragging: boolean) => void) | undefined, currentDocument?: HTMLDocument) {
         if (!this._glassShowing) {
@@ -92,6 +85,9 @@ class DragDrop {
             this._glass!.tabIndex = -1;
             this._glass!.focus();
             this._glass!.addEventListener("keydown", this._onKeyPress);
+            this._glass!.addEventListener("dragenter", this._onDragEnter, { passive: false });
+            this._glass!.addEventListener("dragover", this._onMouseMove, { passive: false });
+            this._glass!.addEventListener("dragleave", this._onDragLeave, { passive: false });
             this._glassShowing = true;
             this._fDragCancel = fCancel;
             this._manualGlassManagement = false;
@@ -103,7 +99,6 @@ class DragDrop {
 
     hideGlass() {
         if (this._glassShowing) {
-            this._glass!.style.pointerEvents = "auto";
             this._document!.body.removeChild(this._glass!);
             this._glassShowing = false;
             this._document = undefined;

--- a/src/Rect.ts
+++ b/src/Rect.ts
@@ -18,6 +18,11 @@ class Rect {
         this.height = height;
     }
 
+    static fromElement(element: Element) {
+      let {x, y, width, height} = element.getBoundingClientRect();
+      return new Rect(x, y, width, height);
+    }
+
     clone() {
         return new Rect(this.x, this.y, this.width, this.height);
     }
@@ -38,16 +43,16 @@ class Rect {
         return this.x + this.width;
     }
 
-    positionElement(element: HTMLElement) {
-        this.styleWithPosition(element.style);
+    positionElement(element: HTMLElement, position?: string) {
+        this.styleWithPosition(element.style, position);
     }
 
-    styleWithPosition(style: JSMap<any>) {
+    styleWithPosition(style: JSMap<any>, position: string = "absolute") {
         style.left = this.x + "px";
         style.top = this.y + "px";
         style.width = Math.max(0, this.width) + "px"; // need Math.max to prevent -ve, cause error in IE
         style.height = Math.max(0, this.height) + "px";
-        style.position = "absolute";
+        style.position = position;
         return style;
     }
 

--- a/src/view/Layout.tsx
+++ b/src/view/Layout.tsx
@@ -755,7 +755,6 @@ export class Layout extends React.Component<ILayoutProps, ILayoutState> {
             // Mimic addTabWithDragAndDrop, but pass in DragEvent
             this.fnNewNodeDropped = drag.onDrop;
             this.newTabJson = drag.json;
-            DragDrop.instance.disableGlassPointerEvents();
             this.dragStart(event, drag.dragText, TabNode._fromJson(drag.json, this.props.model, false), true, undefined, undefined);
         }
     }


### PR DESCRIPTION
This is an attempt to fix the [issue reported](https://github.com/caplin/FlexLayout/pull/196#issuecomment-813021173) with external drag, that you can't drag over an iframe.  I figured out how to get the glass to work even with pointer events enabled: just needed to listen to some more drag events.  So now the behavior should be:
* You can drag an external link onto the FlexLayout, even over an iframe in the FlexLayout
* You still cannot drag a link from within an iframe onto the page. I believe this is because of  [this security feature](https://bugs.chromium.org/p/chromium/issues/detail?id=59081), so we would need [this Chrome feature request](https://bugs.chromium.org/p/chromium/issues/detail?id=981124), to fix it.

I'm a little unhappy with how, once you start dragging onto the FlexLayout, it takes control of dragging of the entire window (not just the FlexLayout area).  I think it would be better to size the glass to match the FlexLayout in the case of dragenter events.  For internal dragging, I imagine we want to keep the full-window-size glass, as it doesn't (currently?) make sense to drag a FlexLayout tab outside its own layout.  Although I do find that this makes it hard to cancel a drag... the only way is with <kbd>Escape</kbd>, whereas dropping outside the FlexLayout should perhaps cancel the drag?  But that's more of a `onMouseMove` behavior I'd like to improve.