### PR TITLE
Fix dragging of splitters

### DIFF
--- a/src/view/Splitter.tsx
+++ b/src/view/Splitter.tsx
@@ -24,7 +24,7 @@ export const Splitter = (props: ISplitterProps) => {
     const parentNode = node.getParent() as RowNode | BorderNode;
 
     const onMouseDown = (event: Event | React.MouseEvent<HTMLDivElement, MouseEvent> | React.TouchEvent<HTMLDivElement>) => {
-        DragDrop.instance.startDrag(event, onDragStart, onDragMove, onDragEnd, onDragCancel, undefined, undefined, layout.getCurrentDocument());
+        DragDrop.instance.startDrag(event, onDragStart, onDragMove, onDragEnd, onDragCancel, undefined, undefined, layout.getCurrentDocument(), layout.getRootDiv());
         pBounds.current = parentNode._getSplitterBounds(node, true);
         const rootdiv = layout.getRootDiv();
         outlineDiv.current = layout.getCurrentDocument()!.createElement("div");


### PR DESCRIPTION
I noticed that dragging splitters does not work well when tabs have iframes in them, at least in my app: if you drag so fast that your mouse gets over an iframe, then the drag hangs and FlexLayout gets confused.

It seems that the default glass sizing to match `document.body` does not work well (I guess then there's a difference between `position: absolute` and `position: fixed`).  But specifying the `rootElement` explicitly works well.

This is the last untouched call to `startDrag`, so hopefully the last bug fix.  Sorry for not catching it earlier.