### PR TITLE
Eliminate a lot of getBoundingClientRect

### DIFF
--- a/src/view/BorderButton.tsx
+++ b/src/view/BorderButton.tsx
@@ -6,6 +6,7 @@ import Rect from "../Rect";
 import { IIcons, ILayoutCallbacks, ITitleObject } from "./Layout";
 import { ICloseType } from "../model/ICloseType";
 import { CLASSES } from "../Types";
+import { getElementBounds } from "./GetElementBounds";
 
 /** @hidden @internal */
 export interface IBorderButtonProps {
@@ -59,13 +60,13 @@ export const BorderButton = (props: IBorderButtonProps) => {
     };
 
     React.useLayoutEffect(() => {
-        updateRect();
+        if (!node.getTabRect()) updateRect();
+        else getElementBounds([selfRef.current!]).then(es => updateRect(es[0]));
     });
 
-    const updateRect = () => {
+    const updateRect = (r = selfRef.current!.getBoundingClientRect()) => {
         // record position of tab in border
         const clientRect = layout.getDomRect();
-        const r = selfRef.current!.getBoundingClientRect();
         node._setTabRect(new Rect(r.left - clientRect.left, r.top - clientRect.top, r.width, r.height));
     };
 

--- a/src/view/GetElementBounds.ts
+++ b/src/view/GetElementBounds.ts
@@ -1,0 +1,31 @@
+export function getElementBounds<E extends readonly (HTMLElement | undefined)[]>(elements: E): Promise<{ [K in keyof E]: DOMRectReadOnly }> {
+    return new Promise((accept, reject) => {
+        let observer: IntersectionObserver;
+        observer = new IntersectionObserver((entries: (IntersectionObserverEntry | undefined)[]) => {
+            if (entries.length === elements.length) {
+                //reject("assertion fail");
+                entries.push(...new Array<undefined>(elements.length - entries.length));
+            }
+
+            // reorder entries to match elements
+            for (let i = 0; i < elements.length; i++) {
+                const element = elements[i];
+
+                // if this entry is not the element, swap it with the entry that is
+                // this will guarantee the correct sorted order, as long as each entry in elements is unique
+                // this is not a stable sort with undefineds but it doesn't matter as undefined only has one value
+                if (entries[i]?.target != element) {
+                    const found = entries.findIndex(e => e?.target === element);
+                    const foundEntry = entries[found];
+                    entries[found] = entries[i];
+                    entries[i] = foundEntry;
+                }
+            }
+
+            observer.disconnect();
+            accept(entries.map(e => e?.boundingClientRect) as any);
+        });
+
+        elements.forEach(e => e && observer.observe(e));
+    });
+}

--- a/src/view/Layout.tsx
+++ b/src/view/Layout.tsx
@@ -157,6 +157,8 @@ export class Layout extends React.Component<ILayoutProps, ILayoutState> {
     private previousModel?: Model;
     /** @hidden @internal */
     private centerRect?: Rect;
+    /** @hidden @internal */
+    private selfRect: DOMRectReadOnly;
 
     /** @hidden @internal */
     // private start: number = 0;
@@ -219,6 +221,7 @@ export class Layout extends React.Component<ILayoutProps, ILayoutState> {
         this.findHeaderBarSizeRef = React.createRef<HTMLDivElement>();
         this.findTabBarSizeRef = React.createRef<HTMLDivElement>();
         this.findBorderBarSizeRef = React.createRef<HTMLDivElement>();
+        this.selfRect = new DOMRect();
         this.supportsPopout = props.supportsPopout !== undefined ? props.supportsPopout : defaultSupportsPopout;
         this.popoutURL = props.popoutURL ? props.popoutURL : "popout.html";
         // For backwards compatibility, prop closeIcon sets prop icons.close:
@@ -303,7 +306,8 @@ export class Layout extends React.Component<ILayoutProps, ILayoutState> {
     }
 
     /** @hidden @internal */
-    updateRect = (domRect: DOMRectReadOnly = this.getDomRect()) => {
+    updateRect = (domRect: DOMRectReadOnly = this.selfRef.current!.getBoundingClientRect()) => {
+        this.selfRect = domRect;
         const rect = new Rect(0, 0, domRect.width, domRect.height);
         if (!rect.equals(this.state.rect) && rect.width !== 0 && rect.height !== 0) {
             this.setState({ rect });
@@ -348,7 +352,7 @@ export class Layout extends React.Component<ILayoutProps, ILayoutState> {
 
     /** @hidden @internal */
     getDomRect() {
-        return this.selfRef.current!.getBoundingClientRect();
+        return this.selfRect;
     }
 
     /** @hidden @internal */
@@ -581,7 +585,7 @@ export class Layout extends React.Component<ILayoutProps, ILayoutState> {
     /** @hidden @internal */
     _getScreenRect(node: TabNode) {
         const rect = node!.getRect()!.clone();
-        const bodyRect: DOMRect = this.selfRef.current!.getBoundingClientRect();
+        const bodyRect = this.selfRect;
         const navHeight = Math.min(80, this.currentWindow!.outerHeight - this.currentWindow!.innerHeight);
         const navWidth = Math.min(80, this.currentWindow!.outerWidth - this.currentWindow!.innerWidth);
         rect.x = rect.x + bodyRect.x + this.currentWindow!.screenX + navWidth;
@@ -748,7 +752,7 @@ export class Layout extends React.Component<ILayoutProps, ILayoutState> {
             this.outlineDiv!.style.transition = `top ${speed}s, left ${speed}s, width ${speed}s, height ${speed}s`;
         }
         this.firstMove = false;
-        const clientRect = this.selfRef.current!.getBoundingClientRect();
+        const clientRect = this.selfRect;
         const pos = {
             x: event.clientX - clientRect.left,
             y: event.clientY - clientRect.top,

--- a/src/view/Layout.tsx
+++ b/src/view/Layout.tsx
@@ -23,6 +23,7 @@ import { FloatingWindow } from "./FloatingWindow";
 import { FloatingWindowTab } from "./FloatingWindowTab";
 import { TabFloating } from "./TabFloating";
 import { IJsonTabNode } from "../model/IJsonModel";
+import { getElementBounds } from "./GetElementBounds";
 
 export interface ILayoutProps {
     model: Model;
@@ -286,9 +287,7 @@ export class Layout extends React.Component<ILayoutProps, ILayoutState> {
         // need to re-render if size changes
         this.currentDocument = (this.selfRef.current as HTMLDivElement).ownerDocument;
         this.currentWindow = this.currentDocument.defaultView!;
-        this.resizeObserver = new ResizeObserver(entries => {
-            this.updateRect(entries[0].contentRect);
-        });
+        this.resizeObserver = new ResizeObserver(() => getElementBounds([this.selfRef.current!]).then(es => this.updateRect(es[0])));
         this.resizeObserver.observe(this.selfRef.current!);
     }
 
@@ -316,24 +315,26 @@ export class Layout extends React.Component<ILayoutProps, ILayoutState> {
 
     /** @hidden @internal */
     updateLayoutMetrics = () => {
-        if (this.findHeaderBarSizeRef.current) {
-            const headerBarSize = this.findHeaderBarSizeRef.current.getBoundingClientRect().height;
-            if (headerBarSize !== this.state.calculatedHeaderBarSize) {
+        getElementBounds([
+            this.findHeaderBarSizeRef.current || undefined,
+            this.findTabBarSizeRef.current || undefined,
+            this.findBorderBarSizeRef.current || undefined
+        ]).then(([headerBar, tabBar, borderBar]) => {
+            const headerBarSize = headerBar?.height;
+            if (headerBarSize !== undefined && headerBarSize !== this.state.calculatedHeaderBarSize) {
                 this.setState({ calculatedHeaderBarSize: headerBarSize });
             }
-        }
-        if (this.findTabBarSizeRef.current) {
-            const tabBarSize = this.findTabBarSizeRef.current.getBoundingClientRect().height;
-            if (tabBarSize !== this.state.calculatedTabBarSize) {
+
+            const tabBarSize = tabBar?.height;
+            if (tabBarSize !== undefined && tabBarSize !== this.state.calculatedTabBarSize) {
                 this.setState({ calculatedTabBarSize: tabBarSize });
             }
-        }
-        if (this.findBorderBarSizeRef.current) {
-            const borderBarSize = this.findBorderBarSizeRef.current.getBoundingClientRect().height;
-            if (borderBarSize !== this.state.calculatedBorderBarSize) {
+
+            const borderBarSize = borderBar?.height;
+            if (borderBarSize !== undefined && borderBarSize !== this.state.calculatedBorderBarSize) {
                 this.setState({ calculatedBorderBarSize: borderBarSize });
             }
-        }
+        })
     };
 
     /** @hidden @internal */

--- a/src/view/TabButton.tsx
+++ b/src/view/TabButton.tsx
@@ -7,6 +7,7 @@ import Rect from "../Rect";
 import { IIcons, ILayoutCallbacks, ITitleObject } from "./Layout";
 import { ICloseType } from "../model/ICloseType";
 import { CLASSES } from "../Types";
+import { getElementBounds } from "./GetElementBounds";
 
 /** @hidden @internal */
 export interface ITabButtonProps {
@@ -87,18 +88,19 @@ export const TabButton = (props: ITabButtonProps) => {
     };
 
     React.useLayoutEffect(() => {
-        updateRect();
+        if (!node.getTabRect()) updateRect();
+        else getElementBounds([selfRef.current!, contentRef.current!]).then(es => updateRect(...es));
+
         if (layout.getEditingTab() === node) {
             (contentRef.current! as HTMLInputElement).select();
         }
     });
 
-    const updateRect = () => {
+    const updateRect = (r = selfRef.current!.getBoundingClientRect(), c = contentRef.current!.getBoundingClientRect()) => {
         // record position of tab in node
         const layoutRect = layout.getDomRect();
-        const r = selfRef.current!.getBoundingClientRect();
         node._setTabRect(new Rect(r.left - layoutRect.left, r.top - layoutRect.top, r.width, r.height));
-        contentWidth.current = contentRef.current!.getBoundingClientRect().width;
+        contentWidth.current = c.width;
     };
 
     const onTextBoxMouseDown = (event: React.MouseEvent<HTMLInputElement> | React.TouchEvent<HTMLInputElement>) => {

--- a/src/view/TabOverflowHook.tsx
+++ b/src/view/TabOverflowHook.tsx
@@ -4,6 +4,7 @@ import Rect from "../Rect";
 import TabSetNode from "../model/TabSetNode";
 import BorderNode from "../model/BorderNode";
 import Orientation from "../Orientation";
+import { getElementBounds } from "./GetElementBounds";
 
 /** @hidden @internal */
 export const useTabOverflow = (
@@ -27,7 +28,7 @@ export const useTabOverflow = (
     }, [node.getSelectedNode(), node.getRect().width, node.getRect().height]);
 
     React.useLayoutEffect(() => {
-        updateVisibleTabs();
+        getElementBounds([stickyButtonsRef.current!, toolbarRef.current!]).then(es => updateVisibleTabs(es[0], es[1]))
     });
 
     React.useEffect(() => {
@@ -67,14 +68,14 @@ export const useTabOverflow = (
         }
     };
 
-    const updateVisibleTabs = () => {
+    const updateVisibleTabs = (stickyButtonsRect: DOMRectReadOnly, toolbarRect: DOMRectReadOnly) => {
         const tabMargin = 2;
         if (firstRender.current === true ) {
             tabsTruncated.current = false;
         }
         const nodeRect = node instanceof TabSetNode ? node.getRect() : (node as BorderNode).getTabHeaderRect()!;
         let lastChild = node.getChildren()[node.getChildren().length - 1] as TabNode;
-        const stickyButtonsSize = stickyButtonsRef.current === null ? 0 : getSize(stickyButtonsRef.current!.getBoundingClientRect());
+        const stickyButtonsSize = stickyButtonsRef.current === null ? 0 : getSize(stickyButtonsRect);
 
         if (
             firstRender.current === true ||
@@ -85,7 +86,7 @@ export const useTabOverflow = (
             const enabled = node instanceof TabSetNode ? node.isEnableTabStrip() === true : true;
             let endPos = getFar(nodeRect) - stickyButtonsSize;
             if (toolbarRef.current !== null) {
-                endPos -= getSize(toolbarRef.current.getBoundingClientRect());
+                endPos -= getSize(toolbarRect);
             } 
             if (enabled && node.getChildren().length > 0) {
                 if (hiddenTabs.length === 0 && position === 0 && getFar(lastChild.getTabRect()!) + tabMargin < endPos) {

--- a/src/view/TabOverflowHook.tsx
+++ b/src/view/TabOverflowHook.tsx
@@ -28,7 +28,10 @@ export const useTabOverflow = (
     }, [node.getSelectedNode(), node.getRect().width, node.getRect().height]);
 
     React.useLayoutEffect(() => {
-        getElementBounds([stickyButtonsRef.current!, toolbarRef.current!]).then(es => updateVisibleTabs(es[0], es[1]))
+        getElementBounds([
+            stickyButtonsRef.current! || undefined,
+            toolbarRef.current! || undefined
+        ]).then(es => updateVisibleTabs(es[0], es[1]))
     });
 
     React.useEffect(() => {
@@ -75,7 +78,7 @@ export const useTabOverflow = (
         }
         const nodeRect = node instanceof TabSetNode ? node.getRect() : (node as BorderNode).getTabHeaderRect()!;
         let lastChild = node.getChildren()[node.getChildren().length - 1] as TabNode;
-        const stickyButtonsSize = stickyButtonsRef.current === null ? 0 : getSize(stickyButtonsRect);
+        const stickyButtonsSize = !stickyButtonsRect ? 0 : getSize(stickyButtonsRect);
 
         if (
             firstRender.current === true ||
@@ -85,7 +88,7 @@ export const useTabOverflow = (
             lastRect.current = nodeRect;
             const enabled = node instanceof TabSetNode ? node.isEnableTabStrip() === true : true;
             let endPos = getFar(nodeRect) - stickyButtonsSize;
-            if (toolbarRef.current !== null) {
+            if (toolbarRect) {
                 endPos -= getSize(toolbarRect);
             } 
             if (enabled && node.getChildren().length > 0) {


### PR DESCRIPTION
I managed to eliminate almost all of the getBoundingClientRect code that ran on every render (see #245)

The downside is that this makes a surprising amount of code asynchronous (as in, it depends on Promises). It all seemed to compile fine on the dev server, but I'm not sure if this is something you'd be willing to accept. I did manage to refrain from using async/await syntax though.

The biggest issue with this is the tab overflow and, more importantly, _scrolling_ logic:

https://user-images.githubusercontent.com/4723091/131480246-148b8290-77a2-4bad-bbb6-c4e6eebb57b1.mp4

I'm not really sure why this is. Most likely because IntersectionObserver is a very slow way of getting the bounding rect so it's a couple frames off, causing race conditions.