### PR TITLE
Option to set the help text for tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,7 @@ Inherited defaults will take their value from the associated global attributes (
 | component | *required* | string identifying which component to run (for factory) |
 | config | null | a place to hold json config for the hosted component |
 | id | auto generated | |
+| helpText | *optional* | An optional help text for the tab to be displayed upon tab hover. |
 | enableClose | *inherited* | allow user to close tab via close button |
 | closeType | *inherited* | see values in ICloseType |
 | enableDrag | *inherited* | allow user to drag tab to new location |

--- a/src/PopupMenu.tsx
+++ b/src/PopupMenu.tsx
@@ -70,7 +70,7 @@ const PopupMenu = (props: IPopupMenuProps) => {
     };
 
     const itemElements = items.map((item) => (
-        <div key={item.index} className={classNameMapper("flexlayout__popup_menu_item")} onClick={(event) => onItemClick(item, event)}>
+        <div key={item.index} className={classNameMapper("flexlayout__popup_menu_item")} onClick={(event) => onItemClick(item, event)} title={item.node.getHelpText()}>
             {item.node._getRenderedName()}
         </div>
     ));

--- a/src/model/TabNode.ts
+++ b/src/model/TabNode.ts
@@ -25,6 +25,7 @@ class TabNode extends Node implements IDraggable {
         attributeDefinitions.add("id", undefined).setType(Attribute.STRING);
 
         attributeDefinitions.add("name", "[Unnamed Tab]").setType(Attribute.STRING);
+        attributeDefinitions.add("helpText", undefined).setType(Attribute.STRING);
         attributeDefinitions.add("component", undefined).setType(Attribute.STRING);
         attributeDefinitions.add("config", undefined).setType("any");
         attributeDefinitions.add("floating", false).setType(Attribute.BOOLEAN);
@@ -86,6 +87,10 @@ class TabNode extends Node implements IDraggable {
 
     getName() {
         return this._getAttr("name") as string;
+    }
+
+    getHelpText() {
+        return this._getAttr("helpText") as string | undefined;
     }
 
     getComponent() {

--- a/src/view/BorderButton.tsx
+++ b/src/view/BorderButton.tsx
@@ -129,7 +129,7 @@ export const BorderButton = (props: IBorderButtonProps) => {
     }
 
     return (
-        <div ref={selfRef} style={{}} className={classNames} onMouseDown={onMouseDown} onTouchStart={onMouseDown}>
+        <div ref={selfRef} style={{}} className={classNames} onMouseDown={onMouseDown} onTouchStart={onMouseDown} title={node.getHelpText()}>
             {leading}
             {content}
             {buttons}

--- a/src/view/TabButton.tsx
+++ b/src/view/TabButton.tsx
@@ -212,6 +212,7 @@ export const TabButton = (props: ITabButtonProps) => {
             className={classNames}
             onMouseDown={onMouseDown}
             onTouchStart={onMouseDown}
+            title={node.getHelpText()}
         >
             {leading}
             {content}


### PR DESCRIPTION
### Requirement

As a developer, I should be able to set the help text for the created tabs to enhance usability. Especially, when a large number of tabs are open in a give `TabSet`.

### Proposed Solution

Provide a configuration option for tabs that can aid a developer to specify the help text to be displayed upon tab hover. This PR aims to expose such an option, `helpText`.

