### PR TITLE
Use UUIDs for IDs

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
         "@types/node": "^15.0.2",
         "@types/react": "^17.0.5",
         "@types/react-dom": "^17.0.4",
+        "@types/uuid": "^8.3.1",
         "awesome-typescript-loader": "^5.2.0",
         "jasmine": "^3.7.0",
         "prettier": "^2.3.0",
@@ -54,5 +55,7 @@
         "typescript": "^4.2.4",
         "webpack-cli": "^4.7.0"
     },
-    "dependencies": {}
+    "dependencies": {
+        "uuid": "^8.3.2"
+    }
 }

--- a/src/model/Model.ts
+++ b/src/model/Model.ts
@@ -458,7 +458,7 @@ class Model {
 
     /** @hidden @internal */
     _nextUniqueId() {
-        return uuid.v4();
+        return '#' + uuid.v4();
     }
 
     /** @hidden @internal */

--- a/src/model/Model.ts
+++ b/src/model/Model.ts
@@ -17,6 +17,7 @@ import TabNode from "./TabNode";
 import TabSetNode from "./TabSetNode";
 import {ITabSetAttributes} from "./IJsonModel";
 import { adjustSelectedIndexAfterDock, adjustSelectedIndexAfterFloat } from "./Utils";
+import * as uuid from "uuid";
 
 /** @hidden @internal */
 export interface ILayoutMetrics {
@@ -105,8 +106,6 @@ class Model {
     /** @hidden @internal */
     private _idMap: Record<string, Node>;
     /** @hidden @internal */
-    private _nextId: number;
-    /** @hidden @internal */
     private _changeListener?: () => void;
     /** @hidden @internal */
     private _root?: RowNode;
@@ -133,7 +132,6 @@ class Model {
     private constructor() {
         this._attributes = {};
         this._idMap = {};
-        this._nextId = 0;
         this._borders = new BorderSet(this);
         this._pointerFine = true;
     }
@@ -460,12 +458,7 @@ class Model {
 
     /** @hidden @internal */
     _nextUniqueId() {
-        this._nextId++;
-        while (this._idMap["#" + this._nextId] !== undefined) {
-            this._nextId++;
-        }
-
-        return "#" + this._nextId;
+        return uuid.v4();
     }
 
     /** @hidden @internal */


### PR DESCRIPTION
Fixes an issue introduced with #255 where IDs may conflict when they are saved and later introduced.

Downside: introduces 1 dependency. Upside: anyone with React already has this dependency installed.

@nealus This is the fix for that problem with the tab storage