### PR TITLE
Display tooltip text for popup menu items

### DIFF
--- a/src/PopupMenu.tsx
+++ b/src/PopupMenu.tsx
@@ -70,7 +70,7 @@ const PopupMenu = (props: IPopupMenuProps) => {
     };
 
     const itemElements = items.map((item) => (
-        <div key={item.index} className={classNameMapper("flexlayout__popup_menu_item")} onClick={(event) => onItemClick(item, event)}>
+        <div key={item.index} className={classNameMapper("flexlayout__popup_menu_item")} onClick={(event) => onItemClick(item, event)} title={item.node._getRenderedName()}>
             {item.node._getRenderedName()}
         </div>
     ));


### PR DESCRIPTION
## Scenario

The names of the overflown tabs can be long, similar and differing in few aspects only, for instance `a loooooooooooooonnnnnnnggggg tab name (2021.10.1)` and `a loooooooooooooonnnnnnnggggg tab name (2021.10.2)`. In this case the text would be clipped and it is not apparent which tab to select from the overflow menu. A tooltip would aid a user in such conditions.