### PR TITLE
Add MouseEvent to Action data for (at least) tabs

### DIFF
--- a/src/PopupMenu.tsx
+++ b/src/PopupMenu.tsx
@@ -8,7 +8,7 @@ export function showPopup(
     layoutDiv: HTMLDivElement,
     triggerElement: Element,
     items: { index: number; node: TabNode }[],
-    onSelect: (item: { index: number; node: TabNode }) => void,
+    onSelect: (event: React.MouseEvent<HTMLDivElement, MouseEvent>, item: { index: number; node: TabNode }) => void,
     classNameMapper: (defaultClassName: string) => string
 ) {
     const currentDocument = triggerElement.ownerDocument;
@@ -56,7 +56,7 @@ interface IPopupMenuProps {
     items: { index: number; node: TabNode }[];
     currentDocument: Document;
     onHide: () => void;
-    onSelect: (item: { index: number; node: TabNode }) => void;
+    onSelect: (event: React.MouseEvent<HTMLDivElement, MouseEvent>, item: { index: number; node: TabNode }) => void;
     classNameMapper: (defaultClassName: string) => string;
 }
 
@@ -65,7 +65,7 @@ const PopupMenu = (props: IPopupMenuProps) => {
     const { items, onHide, onSelect, classNameMapper } = props;
 
     const onItemClick = (item: { index: number; node: TabNode }, event: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
-        onSelect(item);
+        onSelect(event, item);
         onHide();
         event.stopPropagation();
     };
@@ -76,5 +76,9 @@ const PopupMenu = (props: IPopupMenuProps) => {
         </div>
     ));
 
-    return <div  dir="ltr" className={classNameMapper(CLASSES.FLEXLAYOUT__POPUP_MENU)}>{itemElements}</div>;
+    return (
+        <div dir="ltr" className={classNameMapper(CLASSES.FLEXLAYOUT__POPUP_MENU)}>
+            {itemElements}
+        </div>
+    );
 };

--- a/src/model/Actions.ts
+++ b/src/model/Actions.ts
@@ -72,7 +72,7 @@ class Actions {
      * @param tabsetNodeId the id of the tabset node to delete
      * @returns {Action} the action
      */
-     static deleteTabset(tabsetNodeId: string): Action {
+    static deleteTabset(tabsetNodeId: string): Action {
         return new Action(Actions.DELETE_TABSET, { node: tabsetNodeId });
     }
 
@@ -89,10 +89,11 @@ class Actions {
     /**
      * Selects the given tab in its parent tabset
      * @param tabNodeId the id of the node to set selected
+     * @param event the event that originated the action
      * @returns {Action} the action
      */
-    static selectTab(tabNodeId: string): Action {
-        return new Action(Actions.SELECT_TAB, { tabNode: tabNodeId });
+    static selectTab(tabNodeId: string, event?: Event | React.MouseEvent<HTMLDivElement> | React.TouchEvent<HTMLDivElement> | undefined): Action {
+        return new Action(Actions.SELECT_TAB, { tabNode: tabNodeId, event });
     }
 
     /**

--- a/src/view/BorderButton.tsx
+++ b/src/view/BorderButton.tsx
@@ -25,11 +25,11 @@ export const BorderButton = (props: IBorderButtonProps) => {
 
     const onMouseDown = (event: React.MouseEvent<HTMLDivElement, MouseEvent> | React.TouchEvent<HTMLDivElement>) => {
         const message = layout.i18nName(I18nLabel.Move_Tab, node.getName());
-        props.layout.dragStart(event, message, node, node.isEnableDrag(), onClick, (event2: Event) => undefined);
+        props.layout.dragStart(event, message, node, node.isEnableDrag(), onClick, () => undefined);
     };
 
-    const onClick = () => {
-        layout.doAction(Actions.selectTab(node.getId()));
+    const onClick = (event: Event | React.MouseEvent<HTMLDivElement> | React.TouchEvent<HTMLDivElement>) => {
+        layout.doAction(Actions.selectTab(node.getId(), event));
     };
 
     const isClosable = () => {
@@ -50,7 +50,7 @@ export const BorderButton = (props: IBorderButtonProps) => {
         if (isClosable()) {
             layout.doAction(Actions.deleteTab(node.getId()));
         } else {
-            onClick();
+            onClick(event);
         }
     };
 
@@ -87,8 +87,8 @@ export const BorderButton = (props: IBorderButtonProps) => {
     let name = node.getName();
 
     function isTitleObject(obj: any): obj is ITitleObject {
-        return obj.titleContent !== undefined 
-      }
+        return obj.titleContent !== undefined;
+    }
 
     if (titleFactory !== undefined) {
         const titleObj = titleFactory(node);

--- a/src/view/BorderTabSet.tsx
+++ b/src/view/BorderTabSet.tsx
@@ -39,8 +39,8 @@ export const BorderTabSet = (props: IBorderTabSetProps) => {
         showPopup(layout.getRootDiv(), element, hiddenTabs, onOverflowItemSelect, layout.getClassName);
     };
 
-    const onOverflowItemSelect = (item: { node: TabNode; index: number }) => {
-        layout.doAction(Actions.selectTab(item.node.getId()));
+    const onOverflowItemSelect = (event: React.MouseEvent<HTMLDivElement, MouseEvent>, item: { node: TabNode; index: number }) => {
+        layout.doAction(Actions.selectTab(item.node.getId(), event));
         userControlledLeft.current = false;
     };
 

--- a/src/view/Layout.tsx
+++ b/src/view/Layout.tsx
@@ -141,12 +141,12 @@ export interface ILayoutCallbacks {
     getDomRect(): any;
     getRootDiv(): HTMLDivElement;
     dragStart(
-        event: Event | React.MouseEvent<HTMLDivElement, MouseEvent> | React.TouchEvent<HTMLDivElement> | React.DragEvent<HTMLDivElement> | undefined,
+        event: Event | React.MouseEvent<HTMLDivElement> | React.TouchEvent<HTMLDivElement> | React.DragEvent<HTMLDivElement> | undefined,
         dragDivText: string,
         node: Node & IDraggable,
         allowDrag: boolean,
-        onClick?: (event: Event) => void,
-        onDoubleClick?: (event: Event) => void
+        onClick?: (event: Event | React.MouseEvent<HTMLDivElement> | React.TouchEvent<HTMLDivElement>) => void,
+        onDoubleClick?: (event: Event | React.MouseEvent<HTMLDivElement> | React.TouchEvent<HTMLDivElement>) => void
     ): void;
     customizeTab(
         tabNode: TabNode,

--- a/src/view/TabButton.tsx
+++ b/src/view/TabButton.tsx
@@ -27,18 +27,18 @@ export const TabButton = (props: ITabButtonProps) => {
     const contentRef = React.useRef<HTMLInputElement | null>(null);
     const contentWidth = React.useRef<number>(0);
 
-    const onMouseDown = (event: React.MouseEvent<HTMLDivElement, MouseEvent> | React.TouchEvent<HTMLDivElement>) => {
+    const onMouseDown = (event: Event | React.MouseEvent<HTMLDivElement> | React.TouchEvent<HTMLDivElement>) => {
         if (!layout.getEditingTab()) {
             const message = layout.i18nName(I18nLabel.Move_Tab, node.getName());
             layout.dragStart(event, message, node, node.isEnableDrag(), onClick, onDoubleClick);
         }
     };
 
-    const onClick = () => {
-        layout.doAction(Actions.selectTab(node.getId()));
+    const onClick = (event: Event | React.MouseEvent<HTMLDivElement> | React.TouchEvent<HTMLDivElement>) => {
+        layout.doAction(Actions.selectTab(node.getId(), event));
     };
 
-    const onDoubleClick = (event: Event) => {
+    const onDoubleClick = (event: Event | React.MouseEvent<HTMLDivElement> | React.TouchEvent<HTMLDivElement>) => {
         if (node.isEnableRename()) {
             layout.setEditingTab(node);
             layout.getCurrentDocument()!.body.addEventListener("mousedown", onEndEdit);
@@ -78,7 +78,7 @@ export const TabButton = (props: ITabButtonProps) => {
         if (isClosable()) {
             layout.doAction(Actions.deleteTab(node.getId()));
         } else {
-            onClick();
+            onClick(event);
         }
     };
 

--- a/src/view/TabSet.tsx
+++ b/src/view/TabSet.tsx
@@ -17,7 +17,7 @@ export interface ITabSetProps {
     iconFactory?: (node: TabNode) => React.ReactNode | undefined;
     titleFactory?: (node: TabNode) => React.ReactNode | undefined;
     icons?: IIcons;
-    editingTab?: TabNode; 
+    editingTab?: TabNode;
 }
 
 /** @hidden @internal */
@@ -36,8 +36,8 @@ export const TabSet = (props: ITabSetProps) => {
         showPopup(layout.getRootDiv(), element, hiddenTabs, onOverflowItemSelect, layout.getClassName);
     };
 
-    const onOverflowItemSelect = (item: { node: TabNode; index: number }) => {
-        layout.doAction(Actions.selectTab(item.node.getId()));
+    const onOverflowItemSelect = (event: Event | React.MouseEvent<HTMLDivElement> | React.TouchEvent<HTMLDivElement>, item: { node: TabNode; index: number }) => {
+        layout.doAction(Actions.selectTab(item.node.getId(), event));
         userControlledLeft.current = false;
     };
 
@@ -51,7 +51,7 @@ export const TabSet = (props: ITabSetProps) => {
         layout.doAction(Actions.setActiveTabset(node.getId()));
         if (!layout.getEditingTab()) {
             const message = layout.i18nName(I18nLabel.Move_Tabset, name);
-            layout.dragStart(event, message, node, node.isEnableDrag(), (event2: Event) => undefined, onDoubleClick);
+            layout.dragStart(event, message, node, node.isEnableDrag(), () => undefined, onDoubleClick);
         }
     };
 
@@ -75,7 +75,7 @@ export const TabSet = (props: ITabSetProps) => {
         }
     };
 
-    const onDoubleClick = (event: Event) => {
+    const onDoubleClick = (event: Event | React.MouseEvent<HTMLDivElement> | React.TouchEvent<HTMLDivElement>) => {
         if (node.canMaximize()) {
             layout.maximize(node);
         }
@@ -134,16 +134,20 @@ export const TabSet = (props: ITabSetProps) => {
         if (tabsTruncated) {
             buttons = [...stickyButtons, ...buttons];
         } else {
-            tabs.push(<div
-                ref={stickyButtonsRef}
-                key="sticky_buttons_container"
-                onMouseDown={onInterceptMouseDown}
-                onTouchStart={onInterceptMouseDown}
-                onDragStart={(e) => { e.preventDefault() }}
-                className={cm(CLASSES.FLEXLAYOUT__TAB_TOOLBAR_STICKY_BUTTONS_CONTAINER)}
-            >
-                {stickyButtons}
-            </div>);
+            tabs.push(
+                <div
+                    ref={stickyButtonsRef}
+                    key="sticky_buttons_container"
+                    onMouseDown={onInterceptMouseDown}
+                    onTouchStart={onInterceptMouseDown}
+                    onDragStart={(e) => {
+                        e.preventDefault();
+                    }}
+                    className={cm(CLASSES.FLEXLAYOUT__TAB_TOOLBAR_STICKY_BUTTONS_CONTAINER)}
+                >
+                    {stickyButtons}
+                </div>
+            );
         }
     }
 
@@ -217,11 +221,15 @@ export const TabSet = (props: ITabSetProps) => {
     }
 
     toolbar = (
-        <div key="toolbar" ref={toolbarRef}
+        <div
+            key="toolbar"
+            ref={toolbarRef}
             className={cm(CLASSES.FLEXLAYOUT__TAB_TOOLBAR)}
             onMouseDown={onInterceptMouseDown}
             onTouchStart={onInterceptMouseDown}
-            onDragStart={(e) => { e.preventDefault() }}
+            onDragStart={(e) => {
+                e.preventDefault();
+            }}
         >
             {buttons}
         </div>
@@ -245,13 +253,16 @@ export const TabSet = (props: ITabSetProps) => {
     }
 
     if (showHeader) {
-
         const headerToolbar = (
-            <div key="toolbar" ref={toolbarRef}
+            <div
+                key="toolbar"
+                ref={toolbarRef}
                 className={cm(CLASSES.FLEXLAYOUT__TAB_TOOLBAR)}
                 onMouseDown={onInterceptMouseDown}
                 onTouchStart={onInterceptMouseDown}
-                onDragStart={(e) => { e.preventDefault() }}
+                onDragStart={(e) => {
+                    e.preventDefault();
+                }}
             >
                 {headerButtons}
             </div>


### PR DESCRIPTION
Hi there,

First of all, amazing work on FlexLayout, it is a really nice library.

I find myself in need of a tiny feature, for `Action`s, mainly, what I would like is the ability to know if an `Action::selectTab` has been triggered by a middle-click from the mouse in order for me to close that tab. I know this could be in-housed in the library (globally/per-tab with the options), but for now, this PR allows to propagate the event to whoever is interested in it.

I don't feel very confident about the PR mainly because there are no test suite in the project.  
But that said, it also does not mean that I've introduced bugs.  

Anyway, if you find no weird things in my fix then I'll be happy to have it merged :+1: 

*NB: Sorry for the formatting, I call my formatter without even thinking about it. If you want me to re-do the PR without those I'll gladly do it.*