### PR TITLE
fixed a bug from tabIcon can't show

### DIFF
--- a/src/view/TabButton.tsx
+++ b/src/view/TabButton.tsx
@@ -170,7 +170,7 @@ export const TabButton = (props: ITabButtonProps) => {
         }
     }
 
-    if (typeof leadingContent === undefined && typeof node.getIcon() !== undefined) {
+    if (typeof leadingContent === "undefined" && typeof node.getIcon() !== "undefined") {
         leadingContent = <img src={node.getIcon()} alt="leadingContent" />;
     }
 


### PR DESCRIPTION
fixed a bug from tabIcon can't show, because (typeof undefined) return a string value 'undefined' is not equal undefined;

typeof undefined === undefined     // false
typeof undefined === "undefined" // true