### PR TITLE
Add FloatWindowContainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ The `<Layout>` component renders the tabsets and splitters, it takes the followi
 | onShowOverflowMenu | callback for handling the display of the tab overflow menu |
 | iconFactory      | a factory function for creating icon components for tab bar buttons. <br/><br/> NOTE: for greater customization of the tab use onRenderTab instead of this callback |
 | titleFactory     | a factory function for creating title components for tab bar buttons. <br /><br /> NOTE: for greater customization of the tab use onRenderTab instead of this callback  |
+| FloatWindowContainer | a react component that wrap float window tab. Useful for those using @mui and @emotion |
 
 
 The model is tree of Node objects that define the structure of the layout.

--- a/src/model/FloatWindowContainer.ts
+++ b/src/model/FloatWindowContainer.ts
@@ -1,0 +1,8 @@
+import { ReactNode, FC } from "react";
+
+export interface FloatWindowContainerProps {
+    children: ReactNode;
+    containerEl: HTMLElement;
+}
+
+export type IFloatWindowContainer = FC<FloatWindowContainerProps>;

--- a/src/view/FloatingWindow.tsx
+++ b/src/view/FloatingWindow.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { createPortal } from "react-dom";
 import { Rect } from "../Rect";
 import { CLASSES } from "../Types";
+import { IFloatWindowContainer } from '../model/FloatWindowContainer'
 
 /** @internal */
 export interface IFloatingWindowProps {
@@ -11,6 +12,7 @@ export interface IFloatingWindowProps {
     rect: Rect;
     onCloseWindow: (id: string) => void;
     onSetWindow: (id: string, window: Window) => void;
+    FloatWindowContainer?: IFloatWindowContainer;
 }
 
 interface IStyleSheet {
@@ -21,7 +23,7 @@ interface IStyleSheet {
 
 /** @internal */
 export const FloatingWindow = (props: React.PropsWithChildren<IFloatingWindowProps>) => {
-    const { title, id, url, rect, onCloseWindow, onSetWindow, children } = props;
+    const { title, id, url, rect, onCloseWindow, onSetWindow, FloatWindowContainer, children } = props;
     const popoutWindow = React.useRef<Window | null>(null);
     const [content, setContent] = React.useState<HTMLElement | undefined>(undefined);
 
@@ -95,7 +97,14 @@ export const FloatingWindow = (props: React.PropsWithChildren<IFloatingWindowPro
     }, []);
 
     if (content !== undefined) {
-        return createPortal(children, content!);
+        return createPortal(
+            FloatWindowContainer
+                ? <FloatWindowContainer
+                    children={children}
+                    containerEl={content}
+                />
+                : children,
+            content!);
     } else {
         return null;
     }


### PR DESCRIPTION
For those who are using css-in-js (styled-components, @emotion, etc.), new styles created by those libs are not injected into the floating windows correctly.


Example usage with [@emotion/react](https://www.npmjs.com/package/@emotion/react)

 ```
     <FlexLayout.Layout
        ...
        supportsPopout={true}
        popoutURL="/pop-out-url"
        FloatWindowContainer={FloatWindowContainer}
      />
```

```FloatWindowContainer.tsx

import createCache from '@emotion/cache';
import { CacheProvider } from '@emotion/react';
import { IFloatWindowContainer} from 'flexlayout-react/declarations/model/FloatWindowContainer';

const FloatWindowContainer: IFloatWindowContainer= ({ children, containerEl }) => {
  const cache = useConstant(() => createCache({ key: 'external', container: containerEl }));

  return <CacheProvider value={cache}>{children}</CacheProvider>;
};
```