### PR TITLE
fix chrome warning for wheel event listener

### DIFF
--- a/src/view/TabOverflowHook.tsx
+++ b/src/view/TabOverflowHook.tsx
@@ -33,7 +33,7 @@ export const useTabOverflow = (
 
     React.useEffect(() => {
         const instance = selfRef.current!;
-        instance.addEventListener('wheel', onWheel);
+        instance.addEventListener('wheel', onWheel, { passive: true });
         return () => {
             instance.removeEventListener('wheel', onWheel);
         }

--- a/src/view/TabOverflowHook.tsx
+++ b/src/view/TabOverflowHook.tsx
@@ -33,7 +33,7 @@ export const useTabOverflow = (
 
     React.useEffect(() => {
         const instance = selfRef.current!;
-        instance.addEventListener('wheel', onWheel, { passive: true });
+        instance.addEventListener('wheel', onWheel, { passive: false });
         return () => {
             instance.removeEventListener('wheel', onWheel);
         }


### PR DESCRIPTION
This fixes Chrome warnings about non-passive `wheel` event listener.

<details>

```
[Violation] Added non-passive event listener to a scroll-blocking 'wheel' event. Consider marking event handler as 'passive' to make the page more responsive. See https://www.chromestatus.com/feature/5745543795965952
(anonymous) @ TabOverflowHook.js:44
commitHookEffectListMount @ react-dom.development.js:22795
commitPassiveMountOnFiber @ react-dom.development.js:24505
commitPassiveMountEffects_complete @ react-dom.development.js:24469
commitPassiveMountEffects_begin @ react-dom.development.js:24456
commitPassiveMountEffects @ react-dom.development.js:24444
flushPassiveEffectsImpl @ react-dom.development.js:26639
flushPassiveEffects @ react-dom.development.js:26592
commitRootImpl @ react-dom.development.js:26546
commitRoot @ react-dom.development.js:26326
performSyncWorkOnRoot @ react-dom.development.js:25760
flushSyncCallbacks @ react-dom.development.js:12044
commitRootImpl @ react-dom.development.js:26569
commitRoot @ react-dom.development.js:26326
finishConcurrentRender @ react-dom.development.js:25624
performConcurrentWorkOnRoot @ react-dom.development.js:25453
workLoop @ scheduler.development.js:260
flushWork @ scheduler.development.js:234
performWorkUntilDeadline @ scheduler.development.js:518
```
</details>

To reproduce, run the demo (https://rawgit.com/caplin/FlexLayout/demos/demos/v0.6/demo/index.html) in Chrome (tested with v100.0.4896.75); in case warnings are not logged, reload the page while the console is opened.