### PR TITLE
Allow users to set activeTabset to undefined

### DIFF
--- a/src/model/Actions.ts
+++ b/src/model/Actions.ts
@@ -19,6 +19,7 @@ export class Actions {
     static UPDATE_NODE_ATTRIBUTES = "FlexLayout_UpdateNodeAttributes";
     static FLOAT_TAB = "FlexLayout_FloatTab";
     static UNFLOAT_TAB = "FlexLayout_UnFloatTab";
+    static DESELECT_TABSET = "FlexLayout_DeselectTabset";
 
     /**
      * Adds a tab node to the given tabset node
@@ -164,5 +165,12 @@ export class Actions {
 
     static unFloatTab(nodeId: string): Action {
         return new Action(Actions.UNFLOAT_TAB, { node: nodeId });
+    }
+
+    /**
+     * Deselect the active tab set, setting the active tabset to undefined
+     */
+    static deselectTabset(): Action {
+        return new Action(Actions.DESELECT_TABSET, {})
     }
 }

--- a/src/model/Model.ts
+++ b/src/model/Model.ts
@@ -395,6 +395,10 @@ export class Model {
                 node._updateAttrs(action.data.json);
                 break;
             }
+            case Actions.DESELECT_TABSET: {
+                this._activeTabSet = undefined;
+                break;
+            }
             default:
                 break;
         }


### PR DESCRIPTION
This PR creates a way to not have a selected tab. I needed this feature for a project I'm working on with popout windows and I couldn't find another way to do it. 