### PR TITLE
Add className from the model to Tab

### DIFF
--- a/src/view/Tab.tsx
+++ b/src/view/Tab.tsx
@@ -62,6 +62,7 @@ export const Tab = (props: ITabProps) => {
     }
 
     let className = cm(CLASSES.FLEXLAYOUT__TAB);
+    if (node.getClassName()) className += " " + node.getClassName()
     if (parentNode instanceof BorderNode) {
         className += " " + cm(CLASSES.FLEXLAYOUT__TAB_BORDER);
         className += " " + cm(CLASSES.FLEXLAYOUT__TAB_BORDER_ + parentNode.getLocation().getName());


### PR DESCRIPTION
The `className` property on the model in `type: "tab"` wasn't actually applied to the final Tab.

Example layout:
```ts
const layoutModel = FlexLayout.Model.fromJson({
    borders: [],
    layout: {
        type: "row",
        weight: 100,
        children: [
            {
                type: "tabset",
                weight: 50,
                children: [
                    {
                        type: "tab",
                        name: "Tab",
                        component: "tab-component",
                        className: "customclass",
                    }
                ]
            }
        ]
    }
})
```

Result is now:
```html
<div class="flexlayout__tab customclass" data-layout-path="/ts1/t0" style="left: 118px; top: 32px; width: 546px; height: 890px; position: absolute;">
```