### PR TITLE
Added `action` argument to `onModelChange` prop function call

### DIFF
--- a/src/model/Model.ts
+++ b/src/model/Model.ts
@@ -115,7 +115,7 @@ export class Model {
     /** @internal */
     private _idMap: Record<string, Node>;
     /** @internal */
-    private _changeListener?: () => void;
+    private _changeListener?: (action: Action) => void;
     /** @internal */
     private _root?: RowNode;
     /** @internal */
@@ -150,7 +150,7 @@ export class Model {
     }
 
     /** @internal */
-    _setChangeListener(listener: (() => void) | undefined) {
+    _setChangeListener(listener: ((action: Action) => void) | undefined) {
         this._changeListener = listener;
     }
 
@@ -402,7 +402,7 @@ export class Model {
         this._updateIdMap();
 
         if (this._changeListener !== undefined) {
-            this._changeListener();
+            this._changeListener(action);
         }
 
         return returnVal;

--- a/src/view/Layout.tsx
+++ b/src/view/Layout.tsx
@@ -60,7 +60,7 @@ export interface ILayoutProps {
         tabSetNode: TabSetNode | BorderNode,
         renderValues: ITabSetRenderValues, // change the values in this object as required
     ) => void;
-    onModelChange?: (model: Model) => void;
+    onModelChange?: (model: Model, action: Action) => void;
     onExternalDrag?: (event: React.DragEvent<HTMLDivElement>) => undefined | {
         dragText: string,
         json: any,
@@ -316,10 +316,10 @@ export class Layout extends React.Component<ILayoutProps, ILayoutState> {
     }
 
     /** @internal */
-    onModelChange = () => {
+    onModelChange = (action: Action) => {
         this.forceUpdate();
         if (this.props.onModelChange) {
-            this.props.onModelChange(this.props.model);
+            this.props.onModelChange(this.props.model, action);
         }
     };
 


### PR DESCRIPTION
This is similar to #64 , which has been reverted for an unknown reason.

It's a non-breaking change that adds a 2nd `action` argument to `onModelChange` prop function.
It can help the user determine the source of the change, e.g. for filtering out layout changes that are produced by certain action type.

**Example use case:** I'd like to store layout in localStorage after changes, but ignore changes produces by the user switching between tabs and tabsets since they don't alter page layout.