### PR TITLE
Add function to find first tab set of the root node.

### DIFF
--- a/src/model/Model.ts
+++ b/src/model/Model.ts
@@ -248,6 +248,24 @@ export class Model {
     }
 
     /**
+     * Finds the first/top left tab set of the given node.
+     * @param node The top node you want to begin searching from, deafults to the root node
+     * @returns The first Tab Set
+     */
+    getFirstTabSet(node = this._root as Node): Node
+    {
+        const child = node.getChildren()[0];
+        if (child instanceof TabSetNode)
+        {
+            return child;
+        }
+        else
+        {
+            return this.getFirstTabSet(child);
+        }
+    }
+
+    /**
      * Update the node tree by performing the given action,
      * Actions should be generated via static methods on the Actions class
      * @param action the action to perform


### PR DESCRIPTION
This new function is part of my solution for [Issue 51](https://github.com/caplin/FlexLayout/issues/51). When it tries to add to the active tab set but there is no active tab set I need to find some tab set to add to instead. Ideally layout.addTabToActiveTabSet() would also be changed to use this as well, but I didn't want to submit an MR that could change functionality without hearing from the developers first. 
