### PR TITLE
refactor: use code instead of keyCode for KeyboardEvent

### DIFF
--- a/src/DragDrop.ts
+++ b/src/DragDrop.ts
@@ -228,7 +228,7 @@ export class DragDrop {
 
     /** @internal */
     private _onKeyPress(event: KeyboardEvent) {
-        if (event.keyCode === 27) {
+        if (event.code === 'Escape') {
             // esc
             this._onDragCancel();
         }

--- a/src/view/BorderButton.tsx
+++ b/src/view/BorderButton.tsx
@@ -113,11 +113,10 @@ export const BorderButton = (props: IBorderButtonProps) => {
     };
 
     const onTextBoxKeyPress = (event: React.KeyboardEvent<HTMLInputElement>) => {
-        // console.log(event, event.keyCode);
-        if (event.keyCode === 27) {
+        if (event.code === 'Escape') {
             // esc
             layout.setEditingTab(undefined);
-        } else if (event.keyCode === 13) {
+        } else if (event.code === 'Enter') {
             // enter
             layout.setEditingTab(undefined);
             layout.doAction(Actions.renameTab(node.getId(), (event.target as HTMLInputElement).value));

--- a/src/view/TabButton.tsx
+++ b/src/view/TabButton.tsx
@@ -113,11 +113,10 @@ export const TabButton = (props: ITabButtonProps) => {
     };
 
     const onTextBoxKeyPress = (event: React.KeyboardEvent<HTMLInputElement>) => {
-        // console.log(event, event.keyCode);
-        if (event.keyCode === 27) {
+        if (event.code === 'Escape') {
             // esc
             layout.setEditingTab(undefined);
-        } else if (event.keyCode === 13) {
+        } else if (event.code === 'Enter') {
             // enter
             layout.setEditingTab(undefined);
             layout.doAction(Actions.renameTab(node.getId(), (event.target as HTMLInputElement).value));


### PR DESCRIPTION
keyCode is deprecated. Replaced usages with code instead.