### PR TITLE
.github: use renovate instead of dependabot

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    ":semanticPrefixFixDepsChoreOthers",
+    ":ignoreModulesAndTests",
+    "group:all",
+    "workarounds:all"
+  ],
+  "branchConcurrentLimit": 0
+}


### PR DESCRIPTION
Use renovate bot which supports batched PRs. This will create a single PR for all of your dependencies that is updated by the bot continuously as new changes are added, instead of having one pull request per dependency which is very noisy and pollutes the Pull Requests tab.