### PR TITLE
fix: handle undefined references when page is unmounted

### DIFF
--- a/examples/demo/TabStorage.tsx
+++ b/examples/demo/TabStorage.tsx
@@ -84,7 +84,7 @@ export function TabStorage({ tab, layout }: { tab: TabNode; layout: Layout; }) {
     }, [storedTabs]);
 
     const insertionCallback = useCallback((dragging: TabNode | IJsonTabNode, _: any, __: any, y: number) => {
-        const absoluteY = y + tab.getRect().y + layout.getDomRect().top;
+        const absoluteY = y + tab.getRect().y + (layout.getDomRect()?.top ?? 0);
         const { insertionIndex } = calculateInsertion(absoluteY);
         const json = dragging instanceof TabNode ? dragging.toJson() as IJsonTabNode : dragging;
 
@@ -113,13 +113,13 @@ export function TabStorage({ tab, layout }: { tab: TabNode; layout: Layout; }) {
         }
     }, [calculateInsertion, tab, layout]);
 
-    tab.getExtraData().tabStorage_onTabDrag = useCallback(((dragging, over, x, y, _, refresh) => {
+    tab.getExtraData().tabStorage_onTabDrag = useCallback(((_dragging, _over, x, y, _, refresh) => {
         if (contents && list) {
             const layoutDomRect = layout.getDomRect();
             const tabRect = tab.getRect();
 
-            const rootX = tabRect.x + layoutDomRect.left;
-            const rootY = tabRect.y + layoutDomRect.top;
+            const rootX = tabRect.x + (layoutDomRect?.left ?? 0);
+            const rootY = tabRect.y + (layoutDomRect?.top ?? 0);
             const absX = x + rootX;
             const absY = y + rootY;
 
@@ -172,7 +172,7 @@ export function TabStorage({ tab, layout }: { tab: TabNode; layout: Layout; }) {
         </p>
         <div ref={setList} className="tab-storage-tabs">
             {storedTabs.length === 0 && <div ref={setEmptyElem} className="tab-storage-empty">Looks like there's nothing here! Try dragging a tab over this text.</div>}
-            {storedTabs.map((stored, i) => (
+            {storedTabs.map((stored, _i) => (
                 <div
                     ref={ref => ref ? refs.set(stored.id!, ref) : refs.delete(stored.id!)}
                     className="tab-storage-entry"
@@ -181,7 +181,7 @@ export function TabStorage({ tab, layout }: { tab: TabNode; layout: Layout; }) {
                         e.preventDefault();
                         layout.addTabWithDragAndDrop(stored.name ?? 'Unnamed', stored, (node) => node && setStoredTabs(tabs => tabs.filter(tab => tab !== stored)));
                     }}
-                    onTouchStart={e => {
+                    onTouchStart={_e => {
                         layout.addTabWithDragAndDrop(stored.name ?? 'Unnamed', stored, (node) => node && setStoredTabs(tabs => tabs.filter(tab => tab !== stored)));
                     }}
                 >

--- a/src/PopupMenu.tsx
+++ b/src/PopupMenu.tsx
@@ -18,7 +18,7 @@ export function showPopup(
     const classNameMapper = layout.getClassName;
     const currentDocument = triggerElement.ownerDocument;
     const triggerRect = triggerElement.getBoundingClientRect();
-    const layoutRect = layoutDiv.getBoundingClientRect();
+    const layoutRect = layoutDiv?.getBoundingClientRect() ?? new DOMRect(0, 0, 100, 100);
 
     const elm = currentDocument.createElement("div");
     elm.className = classNameMapper(CLASSES.FLEXLAYOUT__POPUP_MENU_CONTAINER);
@@ -36,12 +36,16 @@ export function showPopup(
     DragDrop.instance.addGlass(() => onHide());
     DragDrop.instance.setGlassCursorOverride("default");
 
-    layoutDiv.appendChild(elm);
+    if (layoutDiv) {
+        layoutDiv.appendChild(elm);
+    }
 
     const onHide = () => {
         layout.hidePortal();
         DragDrop.instance.hideGlass();
-        layoutDiv.removeChild(elm);
+        if (layoutDiv) {
+            layoutDiv.removeChild(elm);
+        }
         elm.removeEventListener("mousedown", onElementMouseDown);
         currentDocument.removeEventListener("mousedown", onDocMouseDown);
     };
@@ -50,7 +54,7 @@ export function showPopup(
         event.stopPropagation();
     };
 
-    const onDocMouseDown = (event: Event) => {
+    const onDocMouseDown = (_event: Event) => {
         onHide();
     };
 

--- a/src/Rect.ts
+++ b/src/Rect.ts
@@ -26,12 +26,8 @@ export class Rect {
         return new Rect(this.x, this.y, this.width, this.height);
     }
 
-    equals(rect: Rect) {
-        if (this.x === rect.x && this.y === rect.y && this.width === rect.width && this.height === rect.height) {
-            return true;
-        } else {
-            return false;
-        }
+    equals(rect: Rect | null | undefined) {
+        return this.x === rect?.x && this.y === rect?.y && this.width === rect?.width && this.height === rect?.height
     }
 
     getBottom() {

--- a/src/view/BorderButton.tsx
+++ b/src/view/BorderButton.tsx
@@ -103,8 +103,17 @@ export const BorderButton = (props: IBorderButtonProps) => {
     const updateRect = () => {
         // record position of tab in node
         const layoutRect = layout.getDomRect();
-        const r = selfRef.current!.getBoundingClientRect();
-        node._setTabRect(new Rect(r.left - layoutRect.left, r.top - layoutRect.top, r.width, r.height));
+        const r = selfRef.current?.getBoundingClientRect();
+        if (r && layoutRect) {
+            node._setTabRect(
+                new Rect(
+                    r.left - layoutRect.left,
+                    r.top - layoutRect.top,
+                    r.width,
+                    r.height
+                )
+            );
+        }
     };
 
     const onTextBoxMouseDown = (event: React.MouseEvent<HTMLInputElement> | React.TouchEvent<HTMLInputElement>) => {

--- a/src/view/FloatingWindow.tsx
+++ b/src/view/FloatingWindow.tsx
@@ -8,7 +8,7 @@ export interface IFloatingWindowProps {
     title: string;
     id: string;
     url: string;
-    rect: Rect;
+    rect: Rect | null;
     onCloseWindow: (id: string) => void;
     onSetWindow: (id: string, window: Window) => void;
 }
@@ -31,7 +31,7 @@ export const FloatingWindow = (props: React.PropsWithChildren<IFloatingWindowPro
             clearTimeout(timerId.current);
         }
         let isMounted = true;
-        const r = rect;
+        const r = rect || new Rect(0, 0, 100, 100);
         // Make a local copy of the styles from the current window which will be passed into
         // the floating window. window.document.styleSheets is mutable and we can't guarantee
         // the styles will exist when 'popoutWindow.load' is called below.
@@ -122,7 +122,7 @@ function copyStyles(doc: Document, styleSheets: IStyleSheet[]): Promise<boolean[
             styleElement.href = styleSheet.href!;
             head.appendChild(styleElement);
             promises.push(
-                new Promise((resolve, reject) => {
+                new Promise((resolve) => {
                     styleElement.onload = () => resolve(true);
                 })
             );

--- a/src/view/Layout.tsx
+++ b/src/view/Layout.tsx
@@ -169,8 +169,8 @@ export interface ILayoutCallbacks {
     getCurrentDocument(): HTMLDocument | undefined;
     getClassName(defaultClassName: string): string;
     doAction(action: Action): Node | undefined;
-    getDomRect(): any;
-    getRootDiv(): HTMLDivElement;
+    getDomRect(): DOMRect | undefined;
+    getRootDiv(): HTMLDivElement | null;
     dragStart(
         event: Event | React.MouseEvent<HTMLDivElement, MouseEvent> | React.TouchEvent<HTMLDivElement> | React.DragEvent<HTMLDivElement> | undefined,
         dragDivText: string | undefined,
@@ -350,7 +350,10 @@ export class Layout extends React.Component<ILayoutProps, ILayoutState> {
         this.resizeObserver = new ResizeObserver(entries => {
             this.updateRect(entries[0].contentRect);
         });
-        this.resizeObserver.observe(this.selfRef.current!);
+        const selfRefCurr = this.selfRef.current;
+        if (selfRefCurr) {
+            this.resizeObserver.observe(selfRefCurr);
+        }
     }
 
     /** @internal */
@@ -367,7 +370,14 @@ export class Layout extends React.Component<ILayoutProps, ILayoutState> {
     }
 
     /** @internal */
-    updateRect = (domRect: DOMRectReadOnly = this.getDomRect()) => {
+    updateRect = (domRect?: DOMRectReadOnly) => {
+        if (!domRect) {
+            domRect = this.getDomRect();
+        }
+        if (!domRect) {
+            // no dom rect available, return.
+            return;
+        }
         const rect = new Rect(0, 0, domRect.width, domRect.height);
         if (!rect.equals(this.state.rect) && rect.width !== 0 && rect.height !== 0) {
             this.setState({ rect });
@@ -412,12 +422,12 @@ export class Layout extends React.Component<ILayoutProps, ILayoutState> {
 
     /** @internal */
     getDomRect() {
-        return this.selfRef.current!.getBoundingClientRect();
+        return this.selfRef.current?.getBoundingClientRect();
     }
 
     /** @internal */
     getRootDiv() {
-        return this.selfRef.current!;
+        return this.selfRef.current;
     }
 
     /** @internal */
@@ -442,7 +452,10 @@ export class Layout extends React.Component<ILayoutProps, ILayoutState> {
 
     /** @internal */
     componentWillUnmount() {
-        this.resizeObserver?.unobserve(this.selfRef.current!)
+        const selfRefCurr = this.selfRef.current;
+        if (selfRefCurr) {
+            this.resizeObserver?.unobserve(selfRefCurr);
+        }
     }
 
     /** @internal */
@@ -601,10 +614,12 @@ export class Layout extends React.Component<ILayoutProps, ILayoutState> {
 
                             const tabBorderWidth = child._getAttr("borderWidth");
                             const tabBorderHeight = child._getAttr("borderHeight");
-                            if (tabBorderWidth !== -1 && border.getLocation().getOrientation() === Orientation.HORZ) {
-                                rect.width = tabBorderWidth;
-                            } else if (tabBorderHeight !== -1 && border.getLocation().getOrientation() === Orientation.VERT) {
-                                rect.height = tabBorderHeight;
+                            if (rect) {
+                                if (tabBorderWidth !== -1 && border.getLocation().getOrientation() === Orientation.HORZ) {
+                                    rect.width = tabBorderWidth;
+                                } else if (tabBorderHeight !== -1 && border.getLocation().getOrientation() === Orientation.VERT) {
+                                    rect.height = tabBorderHeight;
+                                }
                             }
 
                             floatingWindows.push(
@@ -693,7 +708,11 @@ export class Layout extends React.Component<ILayoutProps, ILayoutState> {
     /** @internal */
     _getScreenRect(node: TabNode) {
         const rect = node!.getRect()!.clone();
-        const bodyRect: DOMRect = this.selfRef.current!.getBoundingClientRect();
+        const bodyRect: DOMRect | undefined =
+            this.selfRef.current?.getBoundingClientRect();
+        if (!bodyRect) {
+            return null;
+        }
         const navHeight = Math.min(80, this.currentWindow!.outerHeight - this.currentWindow!.innerHeight);
         const navWidth = Math.min(80, this.currentWindow!.outerWidth - this.currentWindow!.innerWidth);
         rect.x = rect.x + bodyRect.x + this.currentWindow!.screenX + navWidth;
@@ -785,7 +804,9 @@ export class Layout extends React.Component<ILayoutProps, ILayoutState> {
     /** @internal */
     onCancelAdd = () => {
         const rootdiv = this.selfRef.current;
-        rootdiv!.removeChild(this.dragDiv!);
+        if (rootdiv && this.dragDiv) {
+            rootdiv.removeChild(this.dragDiv);
+        }
         this.dragDiv = undefined;
         this.hidePortal();
         if (this.fnNewNodeDropped != null) {
@@ -807,15 +828,21 @@ export class Layout extends React.Component<ILayoutProps, ILayoutState> {
     /** @internal */
     onCancelDrag = (wasDragging: boolean) => {
         if (wasDragging) {
-            const rootdiv = this.selfRef.current!;
+            const rootdiv = this.selfRef.current;
 
-            try {
-                rootdiv.removeChild(this.outlineDiv!);
-            } catch (e) { }
+            const outlineDiv = this.outlineDiv;
+            if (rootdiv && outlineDiv) {
+                try {
+                    rootdiv.removeChild(outlineDiv);
+                } catch (e) {}
+            }
 
-            try {
-                rootdiv.removeChild(this.dragDiv!);
-            } catch (e) { }
+            const dragDiv = this.dragDiv;
+            if (rootdiv && dragDiv) {
+                try {
+                    rootdiv.removeChild(dragDiv);
+                } catch (e) {}
+            }
 
             this.dragDiv = undefined;
             this.hidePortal();
@@ -855,11 +882,31 @@ export class Layout extends React.Component<ILayoutProps, ILayoutState> {
         onDoubleClick?: (event: Event) => void
     ) => {
         if (!allowDrag) {
-            DragDrop.instance.startDrag(event, undefined, undefined, undefined, undefined, onClick, onDoubleClick, this.currentDocument, this.selfRef.current!);
+            DragDrop.instance.startDrag(
+                event,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                onClick,
+                onDoubleClick,
+                this.currentDocument,
+                this.selfRef.current ?? undefined
+            );
         } else {
             this.dragNode = node;
             this.dragDivText = dragDivText;
-            DragDrop.instance.startDrag(event, this.onDragStart, this.onDragMove, this.onDragEnd, this.onCancelDrag, onClick, onDoubleClick, this.currentDocument, this.selfRef.current!);
+            DragDrop.instance.startDrag(
+                event,
+                this.onDragStart,
+                this.onDragMove,
+                this.onDragEnd,
+                this.onCancelDrag,
+                onClick,
+                onDoubleClick,
+                this.currentDocument,
+                this.selfRef.current ?? undefined
+            );
         }
     };
 
@@ -888,18 +935,22 @@ export class Layout extends React.Component<ILayoutProps, ILayoutState> {
         }
 
         // hide div until the render is complete
-        this.dragDiv!.style.visibility = "hidden";
         this.dragRectRendered = false;
-        this.showPortal(
-            <DragRectRenderWrapper
-                // wait for it to be rendered
-                onRendered={() => {
-                    this.dragRectRendered = true;
-                    onRendered?.();
-                }}>
-                {content}
-            </DragRectRenderWrapper>,
-            this.dragDiv!);
+        const dragDiv = this.dragDiv;
+        if (dragDiv) {
+            dragDiv.style.visibility = "hidden";
+            this.showPortal(
+                <DragRectRenderWrapper
+                    // wait for it to be rendered
+                    onRendered={() => {
+                        this.dragRectRendered = true;
+                        onRendered?.();
+                    }}>
+                    {content}
+                </DragRectRenderWrapper>,
+                dragDiv,
+            );
+        }
     };
 
     /** @internal */
@@ -917,11 +968,13 @@ export class Layout extends React.Component<ILayoutProps, ILayoutState> {
     onDragStart = () => {
         this.dropInfo = undefined;
         this.customDrop = undefined;
-        const rootdiv = this.selfRef.current!;
+        const rootdiv = this.selfRef.current;
         this.outlineDiv = this.currentDocument!.createElement("div");
         this.outlineDiv.className = this.getClassName(CLASSES.FLEXLAYOUT__OUTLINE_RECT);
         this.outlineDiv.style.visibility = "hidden";
-        rootdiv.appendChild(this.outlineDiv);
+        if (rootdiv) {
+            rootdiv.appendChild(this.outlineDiv);
+        }
 
         if (this.dragDiv == null) {
             this.dragDiv = this.currentDocument!.createElement("div");
@@ -929,15 +982,17 @@ export class Layout extends React.Component<ILayoutProps, ILayoutState> {
             this.dragDiv.setAttribute("data-layout-path", "/drag-rectangle");
             this.dragRectRender(this.dragDivText, this.dragNode, this.newTabJson);
 
-            rootdiv.appendChild(this.dragDiv);
+            if (rootdiv) {
+                rootdiv.appendChild(this.dragDiv);
+            }
         }
         // add edge indicators
         if (this.props.model.getMaximizedTabset() === undefined) {
             this.setState({ showEdges: this.props.model.isEnableEdgeDock() });
         }
 
-        if (this.dragNode !== undefined && this.dragNode instanceof TabNode && this.dragNode.getTabRect() !== undefined) {
-            this.dragNode.getTabRect()!.positionElement(this.outlineDiv);
+        if (this.dragNode && this.outlineDiv && this.dragNode instanceof TabNode && this.dragNode.getTabRect() !== undefined) {
+            this.dragNode.getTabRect()?.positionElement(this.outlineDiv);
         }
         this.firstMove = true;
 
@@ -948,30 +1003,34 @@ export class Layout extends React.Component<ILayoutProps, ILayoutState> {
     onDragMove = (event: React.MouseEvent<Element>) => {
         if (this.firstMove === false) {
             const speed = this.props.model._getAttribute("tabDragSpeed") as number;
-            this.outlineDiv!.style.transition = `top ${speed}s, left ${speed}s, width ${speed}s, height ${speed}s`;
+            if (this.outlineDiv) {
+                this.outlineDiv.style.transition = `top ${speed}s, left ${speed}s, width ${speed}s, height ${speed}s`;
+            }
         }
         this.firstMove = false;
-        const clientRect = this.selfRef.current!.getBoundingClientRect();
+        const clientRect = this.selfRef.current?.getBoundingClientRect();
         const pos = {
-            x: event.clientX - clientRect.left,
-            y: event.clientY - clientRect.top,
+            x: event.clientX - (clientRect?.left ?? 0),
+            y: event.clientY - (clientRect?.top ?? 0),
         };
 
         this.checkForBorderToShow(pos.x, pos.y);
 
         // keep it between left & right
-        const dragRect = this.dragDiv!.getBoundingClientRect();
+        const dragRect = this.dragDiv?.getBoundingClientRect() ?? new DOMRect(0, 0, 100, 100);
         let newLeft = pos.x - dragRect.width / 2;
-        if (newLeft + dragRect.width > clientRect.width) {
-            newLeft = clientRect.width - dragRect.width;
+        if (newLeft + dragRect.width > (clientRect?.width ?? 0)) {
+            newLeft = (clientRect?.width ?? 0) - dragRect.width;
         }
         newLeft = Math.max(0, newLeft);
 
-        this.dragDiv!.style.left = newLeft + "px";
-        this.dragDiv!.style.top = pos.y + 5 + "px";
-        if (this.dragRectRendered && this.dragDiv!.style.visibility === "hidden") {
-            // make visible once the drag rect has been rendered
-            this.dragDiv!.style.visibility = "visible";
+        if (this.dragDiv) {
+            this.dragDiv.style.left = newLeft + "px";
+            this.dragDiv.style.top = pos.y + 5 + "px";
+            if (this.dragRectRendered && this.dragDiv.style.visibility === "hidden") {
+                // make visible once the drag rect has been rendered
+                this.dragDiv.style.visibility = "visible";
+            }
         }
 
         let dropInfo = this.props.model._findDropTargetNode(this.dragNode!, pos.x, pos.y);
@@ -980,18 +1039,26 @@ export class Layout extends React.Component<ILayoutProps, ILayoutState> {
                 this.handleCustomTabDrag(dropInfo, pos, event);
             } else {
                 this.dropInfo = dropInfo;
-                this.outlineDiv!.className = this.getClassName(dropInfo.className);
-                dropInfo.rect.positionElement(this.outlineDiv!);
-                this.outlineDiv!.style.visibility = "visible";
+                if (this.outlineDiv) {
+                    this.outlineDiv.className = this.getClassName(dropInfo.className);
+                    dropInfo.rect.positionElement(this.outlineDiv);
+                    this.outlineDiv.style.visibility = "visible";
+                }
             }
         }
     };
 
     /** @internal */
     onDragEnd = (event: Event) => {
-        const rootdiv = this.selfRef.current!;
-        rootdiv.removeChild(this.outlineDiv!);
-        rootdiv.removeChild(this.dragDiv!);
+        const rootdiv = this.selfRef.current;
+        if (rootdiv) {
+            if (this.outlineDiv) {
+                rootdiv.removeChild(this.outlineDiv);
+            }
+            if (this.dragDiv) {
+                rootdiv.removeChild(this.dragDiv);
+            }
+        }
         this.dragDiv = undefined;
         this.hidePortal();
 
@@ -1070,16 +1137,19 @@ export class Layout extends React.Component<ILayoutProps, ILayoutState> {
         }
 
         this.dropInfo = dropInfo;
-        this.outlineDiv!.className = this.getClassName(this.customDrop ? CLASSES.FLEXLAYOUT__OUTLINE_RECT : dropInfo.className);
-
-        if (this.customDrop) {
-            this.customDrop.rect.positionElement(this.outlineDiv!);
-        } else {
-            dropInfo.rect.positionElement(this.outlineDiv!);
+        if (this.outlineDiv) {
+            this.outlineDiv.className = this.getClassName(this.customDrop ? CLASSES.FLEXLAYOUT__OUTLINE_RECT : dropInfo.className);
+            if (this.customDrop) {
+                this.customDrop.rect.positionElement(this.outlineDiv);
+            } else {
+                dropInfo.rect.positionElement(this.outlineDiv);
+            }
         }
 
         DragDrop.instance.setGlassCursorOverride(this.customDrop?.cursor);
-        this.outlineDiv!.style.visibility = "visible";
+        if (this.outlineDiv) {
+            this.outlineDiv.style.visibility = "visible";
+        }
 
         try {
             invalidated?.();

--- a/src/view/Splitter.tsx
+++ b/src/view/Splitter.tsx
@@ -24,9 +24,28 @@ export const Splitter = (props: ISplitterProps) => {
     const outlineDiv = React.useRef<HTMLDivElement | undefined>(undefined);
     const parentNode = node.getParent() as RowNode | BorderNode;
 
-    const onMouseDown = (event: Event | React.MouseEvent<HTMLDivElement, MouseEvent> | React.TouchEvent<HTMLDivElement>) => {
-        DragDrop.instance.setGlassCursorOverride(node.getOrientation() === Orientation.HORZ ? "ns-resize" : "ew-resize");
-        DragDrop.instance.startDrag(event, onDragStart, onDragMove, onDragEnd, onDragCancel, undefined, undefined, layout.getCurrentDocument(), layout.getRootDiv());
+    const onMouseDown = (
+        event:
+            | Event
+            | React.MouseEvent<HTMLDivElement, MouseEvent>
+            | React.TouchEvent<HTMLDivElement>
+    ) => {
+        DragDrop.instance.setGlassCursorOverride(
+            node.getOrientation() === Orientation.HORZ
+                ? "ns-resize"
+                : "ew-resize"
+        );
+        DragDrop.instance.startDrag(
+            event,
+            onDragStart,
+            onDragMove,
+            onDragEnd,
+            onDragCancel,
+            undefined,
+            undefined,
+            layout.getCurrentDocument(),
+            layout.getRootDiv() ?? undefined
+        );
         pBounds.current = parentNode._getSplitterBounds(node, true);
         const rootdiv = layout.getRootDiv();
         outlineDiv.current = layout.getCurrentDocument()!.createElement("div");
@@ -41,12 +60,16 @@ export const Splitter = (props: ISplitterProps) => {
         }
 
         r.positionElement(outlineDiv.current);
-        rootdiv.appendChild(outlineDiv.current);
+        if (rootdiv) {
+            rootdiv.appendChild(outlineDiv.current);
+        }
     };
 
-    const onDragCancel = (wasDragging: boolean) => {
+    const onDragCancel = (_wasDragging: boolean) => {
         const rootdiv = layout.getRootDiv();
-        rootdiv.removeChild(outlineDiv.current as Element);
+        if (rootdiv) {
+            rootdiv.removeChild(outlineDiv.current as Element);
+        }
     };
 
     const onDragStart = () => {
@@ -55,6 +78,10 @@ export const Splitter = (props: ISplitterProps) => {
 
     const onDragMove = (event: React.MouseEvent<Element, MouseEvent>) => {
         const clientRect = layout.getDomRect();
+        if (!clientRect) {
+            return;
+        }
+
         const pos = {
             x: event.clientX - clientRect.left,
             y: event.clientY - clientRect.top,
@@ -98,7 +125,9 @@ export const Splitter = (props: ISplitterProps) => {
         updateLayout();
 
         const rootdiv = layout.getRootDiv();
-        rootdiv.removeChild(outlineDiv.current as HTMLDivElement);
+        if (rootdiv) {
+            rootdiv.removeChild(outlineDiv.current as HTMLDivElement);
+        }
     };
 
     const getBoundPosition = (p: number) => {

--- a/src/view/TabButton.tsx
+++ b/src/view/TabButton.tsx
@@ -103,8 +103,17 @@ export const TabButton = (props: ITabButtonProps) => {
     const updateRect = () => {
         // record position of tab in node
         const layoutRect = layout.getDomRect();
-        const r = selfRef.current!.getBoundingClientRect();
-        node._setTabRect(new Rect(r.left - layoutRect.left, r.top - layoutRect.top, r.width, r.height));
+        const r = selfRef.current?.getBoundingClientRect();
+        if (r && layoutRect) {
+            node._setTabRect(
+                new Rect(
+                    r.left - layoutRect.left,
+                    r.top - layoutRect.top,
+                    r.width,
+                    r.height
+                )
+            );
+        }
     };
 
     const onTextBoxMouseDown = (event: React.MouseEvent<HTMLInputElement> | React.TouchEvent<HTMLInputElement>) => {

--- a/src/view/TabOverflowHook.tsx
+++ b/src/view/TabOverflowHook.tsx
@@ -31,13 +31,16 @@ export const useTabOverflow = (
         updateVisibleTabs();
     });
 
+    const instance = selfRef.current;
     React.useEffect(() => {
-        const instance = selfRef.current!;
-        instance.addEventListener('wheel', onWheel, { passive: false });
-        return () => {
-            instance.removeEventListener('wheel', onWheel);
+        if (!instance) {
+            return;
         }
-    }, []);
+        instance.addEventListener("wheel", onWheel, { passive: false });
+        return () => {
+            instance.removeEventListener("wheel", onWheel);
+        };
+    }, [instance]);
 
     // needed to prevent default mouse wheel over tabset/border (cannot do with react event?)
     const onWheel = (event: Event) => {


### PR DESCRIPTION
When FlexLayout is unmounted from the page, there is a race condition where some FlexLayout internal code may attempt to access selfRef.current when it is undefined (as the DOM has already been removed from the page).

The TypeScript code was using the ! operator to ignore the potential null values in that field, which results in null-access errors when unmounting the page.

Various other locations where undefined reference errors were seen have also been fixed to handle the respective variables being undefined.

https://github.com/caplin/FlexLayout/issues/352#issuecomment-1769322206

Fixes: #352