### PR TITLE
Create addEventListener to support adding multiple event listeners.

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,7 +498,7 @@ This would add a new grid component to the tabset with id "NAVIGATION" (where th
 
 ## Tab Node Events
 
-You can handle events on nodes by adding a listener, this would typically be done 
+You can handle events on nodes by adding a listener with `setEventListener` or `addEventListener`. This would typically be done 
 in the components constructor() method.
 
 Example:

--- a/test/Model.test.ts
+++ b/test/Model.test.ts
@@ -504,17 +504,32 @@ describe("Tree", function () {
         });
 
         it("close tab", () => {
-            let closed = false;
-            tab("/ts0/t0").setEventListener("close", () => { closed = true; })
+            let closed1 = false;
+            let closed2 = false;
+            let closed3 = false;
+            let closed4 = false;
+            tab("/ts0/t0").addEventListener("close", () => { closed1 = true; });
+            tab("/ts0/t0").setEventListener("close", () => { closed2 = true; });
+            tab("/ts0/t0").addEventListener("close", () => { closed3 = true; });
+            const close4Callback = () => { closed4 = true; }
+            tab("/ts0/t0").addEventListener("close", close4Callback);
+            tab("/ts0/t0").removeEventListener("close", close4Callback);
             doAction(Actions.deleteTab(tab("/ts0/t0").getId()));
-            expect(closed).equals(true);
+            expect(closed1).equals(false);
+            expect(closed2).equals(true);
+            expect(closed3).equals(true);
+            expect(closed4).equals(false);
         });
 
         it("save tab", () => {
-            let saved = false;
-            tab("/ts0/t0").setEventListener("save", () => { saved = true; })
+            let saved1 = false;
+            let saved2 = false;
+            tab("/ts0/t0").addEventListener("save", () => { saved1 = true; });
+            tab("/ts0/t0").removeEventListener("save");
+            tab("/ts0/t0").addEventListener("save", () => { saved2 = true; });
             model.toJson();
-            expect(saved).equals(true);
+            expect(saved1).equals(false);
+            expect(saved2).equals(true);
         });
 
         it("visibility tab", () => {


### PR DESCRIPTION
Currently, you can only set one event listener at a time using `setEventListener()`, but it would be nice if multiple event listeners were supported.