### PR TITLE
fix: BorderSet and BorderTab support attributes 'show'

### DIFF
--- a/src/view/BorderTabSet.tsx
+++ b/src/view/BorderTabSet.tsx
@@ -219,7 +219,7 @@ export const BorderTabSet = (props: IBorderTabSetProps) => {
         >
             <div
                 style={outerStyle}
-                className={cm(CLASSES.FLEXLAYOUT__BORDER_INNER) + " xxxxx " + cm(CLASSES.FLEXLAYOUT__BORDER_INNER_ + border.getLocation().getName())}
+                className={cm(CLASSES.FLEXLAYOUT__BORDER_INNER) + " " + cm(CLASSES.FLEXLAYOUT__BORDER_INNER_ + border.getLocation().getName())}
             >
                 <div
                     style={innerStyle}

--- a/src/view/BorderTabSet.tsx
+++ b/src/view/BorderTabSet.tsx
@@ -197,7 +197,7 @@ export const BorderTabSet = (props: IBorderTabSetProps) => {
         outerStyle = { width: borderHeight };
     } else if (border.getLocation() === DockLocation.RIGHT) {
         innerStyle = { left: "100%" , top:position};
-        outerStyle = { width: borderHeight };
+        outerStyle = { width: borderHeight};
     } else {
         innerStyle = { left:position};
         outerStyle = { height: borderHeight };
@@ -207,8 +207,8 @@ export const BorderTabSet = (props: IBorderTabSetProps) => {
         <div
             ref={selfRef}
             style={{
-                display: "flex",
-                flexDirection: (border.getOrientation() === Orientation.VERT ? "row" : "column")
+                display: border.isShowing() ? "flex":'none',
+                flexDirection: (border.getOrientation() === Orientation.VERT ? "row" : "column"),
             }}
             className={borderClasses}
             data-layout-path={border.getPath()}
@@ -219,7 +219,7 @@ export const BorderTabSet = (props: IBorderTabSetProps) => {
         >
             <div
                 style={outerStyle}
-                className={cm(CLASSES.FLEXLAYOUT__BORDER_INNER) + " " + cm(CLASSES.FLEXLAYOUT__BORDER_INNER_ + border.getLocation().getName())}
+                className={cm(CLASSES.FLEXLAYOUT__BORDER_INNER) + " xxxxx " + cm(CLASSES.FLEXLAYOUT__BORDER_INNER_ + border.getLocation().getName())}
             >
                 <div
                     style={innerStyle}

--- a/src/view/Layout.tsx
+++ b/src/view/Layout.tsx
@@ -411,7 +411,7 @@ export class LayoutInternal extends React.Component<ILayoutInternalProps, ILayou
                     (border.isAutoHide() && (border.getChildren().length > 0 || this.state.showHiddenBorder === location)));
                 if (showBorder) {
                     borderSetComponents.set(location, <BorderTabSet layout={this} border={border} size={this.state.calculatedBorderBarSize} />);
-                    borderSetContentComponents.set(location, <BorderTab layout={this} border={border} show={border.getSelected() !== -1} />);
+                    borderSetContentComponents.set(location, <BorderTab layout={this} border={border} show={border.getSelected() !== -1 && border.isShowing() }/>);
                 }
             }
 


### PR DESCRIPTION
enable the code :  layoutRef.current.doAction(Actions.updateNodeAttributes("border_right"),{show: true or false }) 