### PR TITLE
fix: BorderSet and borderTab support attributes 'show'

### DIFF
--- a/src/view/BorderTabSet.tsx
+++ b/src/view/BorderTabSet.tsx
@@ -207,7 +207,7 @@ export const BorderTabSet = (props: IBorderTabSetProps) => {
         <div
             ref={selfRef}
             style={{
-                display: "flex",
+                display: border.isShowing() ? "flex" : "none",
                 flexDirection: (border.getOrientation() === Orientation.VERT ? "row" : "column")
             }}
             className={borderClasses}

--- a/src/view/Layout.tsx
+++ b/src/view/Layout.tsx
@@ -411,7 +411,7 @@ export class LayoutInternal extends React.Component<ILayoutInternalProps, ILayou
                     (border.isAutoHide() && (border.getChildren().length > 0 || this.state.showHiddenBorder === location)));
                 if (showBorder) {
                     borderSetComponents.set(location, <BorderTabSet layout={this} border={border} size={this.state.calculatedBorderBarSize} />);
-                    borderSetContentComponents.set(location, <BorderTab layout={this} border={border} show={border.getSelected() !== -1} />);
+                    borderSetContentComponents.set(location, <BorderTab layout={this} border={border} show={border.getSelected() !== -1 && border.isShowing()} />);
                 }
             }
 


### PR DESCRIPTION
enable the code :  layoutRef.current.doAction(Actions.updateNodeAttributes("border_right"),{show: true or false }) 