### PR TITLE
Fix vitest config to make it run in node environment

### DIFF
--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,5 @@
+import { vi } from 'vitest'
+import { webcrypto } from 'node:crypto'
+
+// Mock the global crypto object to use Node.js webcrypto
+vi.stubGlobal('crypto', webcrypto)

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,8 @@ export default defineConfig({
   test: {
     globals: true,     // so can use `describe`/`it` without importing them
     environment: 'node', 
-    include: ['tests/**/*.test.{js,ts}'], 
+    include: ['tests/**/*.test.{js,ts}'],
+    setupFiles: ['./tests/setup.ts'],
   },
 
   define: {


### PR DESCRIPTION
Currently 'npm test' command fails. This PR fixes it.