### PR TITLE
[Draft] Add support for popup (floating div) with toggleable docking mode

### DIFF
--- a/demo/App.tsx
+++ b/demo/App.tsx
@@ -541,6 +541,7 @@ function App() {
                     <div className="toolbar" dir="ltr">
                         <select className="toolbar_control" onChange={onSelectLayout}>
                             <option value="default">Default</option>
+                            <option value="popup">Popup</option>
                             <option value="newfeatures">New Features</option>
                             <option value="simple">Simple</option>
                             <option value="mosaic">Mosaic Style</option>

--- a/demo/public/layouts/popup.layout
+++ b/demo/public/layouts/popup.layout
@@ -1,0 +1,215 @@
+{
+	"global": {
+		"tabSetEnableSingleTabStretch": true
+	},
+	"borders": [],
+	"layout": {
+		"type": "row",
+		"id": "1",
+		"children": [
+			{
+				"type": "tabset",
+				"id": "2",
+				"weight": 0.2,
+				"children": [
+					{
+						"type": "tab",
+						"id": "3",
+						"name": "Layout JSON",
+						"component": "json",
+						"enablePopout": true
+					}
+				],
+				"active": true
+			},
+			{
+				"type": "tabset",
+				"id": "4",
+				"weight": 0.2,
+				"children": [
+					{
+						"type": "tab",
+						"id": "5",
+						"name": "Grid 1",
+						"component": "grid",
+						"icon": "images/article.svg",
+						"enablePopout": true
+					},
+					{
+						"type": "tab",
+						"id": "5b",
+						"name": "Grid 1",
+						"component": "grid",
+						"icon": "images/article.svg",
+						"enablePopout": true
+					}
+				]
+			}
+		]
+	},
+	"popups": {
+		"b0d755f6-b7ca-48d0-bafc-8d37241b3db4": {
+			"rect": {
+				"height": 200,
+				"width": 400,
+				"x": 100,
+				"y": 100
+			},
+			"layout": {
+				"type": "row",
+				"id": "6",
+				"children": [
+					{
+						"type": "tabset",
+						"id": "7",
+						"weight": 1,
+						"children": [
+							{
+								"type": "tab",
+								"id": "8",
+								"name": "Grid 2",
+								"component": "grid",
+								"icon": "images/article.svg"
+							},
+							{
+								"type": "tab",
+								"id": "9",
+								"name": "Grid 3",
+								"component": "grid",
+								"icon": "images/article.svg"
+							}
+						]
+					}
+				]
+			}
+		},
+		"6356e1d9-8b58-4139-9f7c-846ac1185ae0": {
+			"rect": {
+				"height": 200,
+				"width": 400,
+				"x": 600,
+				"y": 200
+			},
+			"layout": {
+				"type": "row",
+				"id": "6h",
+				"children": [
+					{
+						"type": "tabset",
+						"id": "7s",
+						"weight": 1,
+						"children": [
+							{
+								"type": "tab",
+								"id": "8a",
+								"name": "Grid 2dfg",
+								"component": "grid",
+								"icon": "images/article.svg"
+							}
+						]
+					}
+				]
+			}
+		},
+		"8bfed9a6-470d-4309-80f6-ea8ff367f5a4": {
+			"rect": {
+				"height": 100,
+				"width": 800,
+				"x": 100,
+				"y": 600
+			},
+			"layout": {
+				"type": "row",
+				"id": "feb0094c-0aac-421e-9154-1c4998a556c0",
+				"children": [
+					{
+						"type": "tabset",
+						"id": "2a9889d9-cf04-4269-87c9-bbc1759842cf",
+						"weight": 0.2,
+						"children": [
+							{
+								"type": "tab",
+								"id": "6c1e256f-ed5d-4500-88a2-6941fcd18e69",
+								"name": "Layout JSON",
+								"component": "json"
+							}
+						],
+						"active": true
+					},
+					{
+						"type": "tabset",
+						"id": "b0788f86-7a8b-4643-959f-600711f6cab7",
+						"weight": 0.2,
+						"children": [
+							{
+								"type": "tab",
+								"id": "0fe797bf-f9f0-42ff-9bad-28032303b087",
+								"name": "Grid 1",
+								"component": "grid",
+								"icon": "images/article.svg"
+							},
+							{
+								"type": "tab",
+								"id": "d057cdeb-7420-467f-9165-6acf4323712c",
+								"name": "Grid 1",
+								"component": "grid",
+								"icon": "images/article.svg"
+							}
+						]
+					}
+				]
+			}
+		}
+	},
+	"popouts": {
+		"2feb4a46-0d72-458c-9d29-82495938cda7": {
+			"rect": {
+				"height": 300,
+				"width": 800,
+				"x": 100,
+				"y": 600
+			},
+			"layout": {
+				"type": "row",
+				"id": "d0ec924c-3d4b-4484-8ff5-d44722775f70",
+				"children": [
+					{
+						"type": "tabset",
+						"id": "bac93933-288a-4a0b-b9f5-823ec9745570",
+						"weight": 0.2,
+						"children": [
+							{
+								"type": "tab",
+								"id": "2e3d0e6e-aee7-4476-b19b-10f24851b67c",
+								"name": "Layout JSON",
+								"component": "json"
+							}
+						],
+						"active": true
+					},
+					{
+						"type": "tabset",
+						"id": "cce5875c-263d-443a-ad54-3f9476f0ade9",
+						"weight": 0.2,
+						"children": [
+							{
+								"type": "tab",
+								"id": "0cafdc45-5694-412d-8cce-786c86925128",
+								"name": "Grid 1",
+								"component": "grid",
+								"icon": "images/article.svg"
+							},
+							{
+								"type": "tab",
+								"id": "2857d7af-e201-47f6-bdac-5f1c145a2e7e",
+								"name": "Grid 1",
+								"component": "grid",
+								"icon": "images/article.svg"
+							}
+						]
+					}
+				]
+			}
+		}
+	}
+}

--- a/src/I18nLabel.ts
+++ b/src/I18nLabel.ts
@@ -1,5 +1,6 @@
 export enum I18nLabel {
     Close_Tab = "Close",
+    Pin_Tab = "Toggle docking",
     Close_Tabset = "Close tab set",
     Active_Tabset = "Active tab set",
     Move_Tabset = "Move tab set",

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -111,4 +111,7 @@ export enum CLASSES {
 
     FLEXLAYOUT__MINI_SCROLLBAR = "flexlayout__mini_scrollbar",
     FLEXLAYOUT__MINI_SCROLLBAR_CONTAINER = "flexlayout__mini_scrollbar_container",
+
+    FLEXLAYOUT__POPUP = "flexlayout__popup",
+    FLEXLAYOUT__POPUP_TABBAR_OUTER = "flexlayout__popup_tabbar_outer",
 }

--- a/src/model/Actions.ts
+++ b/src/model/Actions.ts
@@ -22,6 +22,9 @@ export class Actions {
     static POPOUT_TABSET = "FlexLayout_PopoutTabset";
     static CLOSE_WINDOW = "FlexLayout_CloseWindow";
     static CREATE_WINDOW = "FlexLayout_CreateWindow";
+    static UPDATE_WINDOW_RECT = "FlexLayout_UpdateWindowRect";
+    static TOGGLE_DOCKING_MODE = "FlexLayout_ToggleDockingMode";
+    static BRING_TO_FRONT = "FlexLayout_BringToFront";
 
     /**
      * Adds a tab node to the given tabset node
@@ -184,5 +187,17 @@ export class Actions {
      */
     static createWindow(layout: IJsonRowNode, rect: IJsonRect): Action {
         return new Action(Actions.CREATE_WINDOW, { layout, rect});
+    }
+
+    static updateWindowRect(windowId: string, updatedRect: {x?: number, y?: number, width?: number, height?: number}): Action {
+        return new Action(Actions.UPDATE_WINDOW_RECT, { windowId, ...updatedRect });
+    }
+
+    static toggleDockingMode(windowId: string): Action {
+        return new Action(Actions.TOGGLE_DOCKING_MODE, { windowId });
+    }
+
+    static bringToFront(windowId: string): Action {
+        return new Action(Actions.BRING_TO_FRONT, { windowId });
     }
 }

--- a/src/model/IJsonModel.ts
+++ b/src/model/IJsonModel.ts
@@ -7,6 +7,7 @@ export interface IJsonModel {
     borders?: IJsonBorderNode[];
     layout: IJsonRowNode; // top level 'row' is horizontal, rows inside rows take opposite orientation to parent row (ie can act as columns)
 	popouts?: Record<string, IJsonPopout>;
+	popups?: Record<string, IJsonPopup>;
 }
 
 export interface IJsonRect {
@@ -17,6 +18,11 @@ export interface IJsonRect {
 }
 
 export interface IJsonPopout {
+    layout: IJsonRowNode;
+	rect: IJsonRect ;
+}
+
+export interface IJsonPopup {
     layout: IJsonRowNode;
 	rect: IJsonRect ;
 }

--- a/src/model/LayoutPopup.ts
+++ b/src/model/LayoutPopup.ts
@@ -1,0 +1,119 @@
+import { Rect } from "../Rect";
+import { IJsonPopup } from "./IJsonModel";
+import { Model } from "./Model";
+import { RowNode } from "./RowNode";
+import { Node } from "./Node";
+import { TabSetNode } from "./TabSetNode";
+import { LayoutInternal } from "../view/Layout";
+
+export class LayoutPopup {
+    private _windowId: string;
+    private _layout: LayoutInternal | undefined;
+    private _rect: Rect;
+    private _window?: Window | undefined;
+    private _root?: RowNode | undefined;
+    private _maximizedTabSet?: TabSetNode | undefined;
+    private _activeTabSet?: TabSetNode | undefined;
+    private _toScreenRectFunction: (rect: Rect) => Rect;
+    private _isDockingMode: boolean = false;
+
+    constructor(windowId: string, rect: Rect) {
+        this._windowId = windowId;
+        this._rect = rect;
+        this._toScreenRectFunction = (r) => r;
+    }
+
+    public visitNodes(fn: (node: Node, level: number) => void) {
+        this.root!.forEachNode(fn, 0);
+    }
+
+    public get windowId(): string {
+        return this._windowId;
+    }
+
+    public get rect(): Rect {
+        return this._rect;
+    }
+
+    public get layout(): LayoutInternal | undefined {
+        return this._layout;
+    }
+
+    public get window(): Window | undefined {
+        return this._window;
+    }
+
+    public get root(): RowNode | undefined {
+        return this._root;
+    }
+
+    public get maximizedTabSet(): TabSetNode | undefined {
+        return this._maximizedTabSet;
+    }
+
+    public get isDockingMode(): boolean {
+        return this._isDockingMode;
+    }
+
+    public get activeTabSet(): TabSetNode | undefined {
+        return this._activeTabSet;
+    }
+
+    /** @internal */
+    public set rect(value: Rect) {
+        this._rect = value;
+    }
+
+    /** @internal */
+    public set layout(value: LayoutInternal) {
+        this._layout = value;
+    }
+
+    /** @internal */
+    public set window(value: Window | undefined) {
+        this._window = value;
+    }
+
+    /** @internal */
+    public set root(value: RowNode | undefined) {
+        this._root = value;
+    }
+
+    /** @internal */
+    public set maximizedTabSet(value: TabSetNode | undefined) {
+        this._maximizedTabSet = value;
+    }
+
+    /** @internal */
+    public set isDockingMode(value: boolean) {
+        this._isDockingMode = value;
+    }
+
+    /** @internal */
+    public set activeTabSet(value: TabSetNode | undefined) {
+        this._activeTabSet = value;
+    }
+
+    /** @internal */
+    public get toScreenRectFunction(): (rect: Rect) => Rect {
+        return this._toScreenRectFunction!;
+    }
+
+    /** @internal */
+    public set toScreenRectFunction(value: (rect: Rect) => Rect) {
+        this._toScreenRectFunction = value;
+    }
+
+    public toJson(): IJsonPopup {
+        return { layout: this.root!.toJson(), rect: this.rect.toJson() }
+    }
+
+    static fromJson(windowJson: IJsonPopup, model: Model, windowId: string): LayoutPopup {
+        const count = model.getwindowsMap().size;
+        const rect = windowJson.rect ? Rect.fromJson(windowJson.rect) : new Rect(50 + 50 * count, 50 + 50 * count, 600, 400);
+        rect.snap(10); // snapping prevents issue where window moves 1 pixel per save/restore on Chrome
+        const layoutWindow = new LayoutPopup(windowId, rect);
+        layoutWindow.root = RowNode.fromJson(windowJson.layout, model, layoutWindow);
+        return layoutWindow;
+    }
+}

--- a/src/model/RowNode.ts
+++ b/src/model/RowNode.ts
@@ -14,12 +14,13 @@ import { Node } from "./Node";
 import { TabSetNode } from "./TabSetNode";
 import { canDockToWindow } from "../view/Utils";
 import { LayoutWindow } from "./LayoutWindow";
+import { LayoutPopup } from './LayoutPopup';
 
 export class RowNode extends Node implements IDropTarget {
     static readonly TYPE = "row";
 
     /** @internal */
-    static fromJson(json: any, model: Model, layoutWindow: LayoutWindow) {
+    static fromJson(json: any, model: Model, layoutWindow: LayoutWindow | LayoutPopup) {
         const newLayoutNode = new RowNode(model, layoutWindow.windowId, json);
 
         if (json.children != null) {

--- a/src/model/TabNode.ts
+++ b/src/model/TabNode.ts
@@ -6,6 +6,7 @@ import { IDraggable } from "./IDraggable";
 import { IJsonTabNode } from "./IJsonModel";
 import { Model } from "./Model";
 import { Node } from "./Node";
+import { RowNode } from './RowNode';
 import { TabSetNode } from "./TabSetNode";
 
 export class TabNode extends Node implements IDraggable {
@@ -100,6 +101,19 @@ export class TabNode extends Node implements IDraggable {
 
     isPoppedOut() {
         return this.getWindowId() !== Model.MAIN_WINDOW_ID;
+    }
+
+    isPopupRoot() {
+        const grandparent = this.parent?.getParent();
+        if (!(grandparent instanceof RowNode)) {
+            return false;
+        }
+
+        if (grandparent.getParent()) {
+            return false;
+        }
+
+        return grandparent.getChildren().length === 1;
     }
 
     isSelected() {

--- a/src/model/TabSetNode.ts
+++ b/src/model/TabSetNode.ts
@@ -10,6 +10,7 @@ import { BorderNode } from "./BorderNode";
 import { IDraggable } from "./IDraggable";
 import { IDropTarget } from "./IDropTarget";
 import { IJsonTabSetNode } from "./IJsonModel";
+import { LayoutPopup } from './LayoutPopup';
 import { LayoutWindow } from "./LayoutWindow";
 import { Model } from "./Model";
 import { Node } from "./Node";
@@ -21,7 +22,7 @@ export class TabSetNode extends Node implements IDraggable, IDropTarget {
     static readonly TYPE = "tabset";
 
     /** @internal */
-    static fromJson(json: any, model: Model, layoutWindow: LayoutWindow) {
+    static fromJson(json: any, model: Model, layoutWindow: LayoutWindow | LayoutPopup) {
         const newLayoutNode = new TabSetNode(model, json);
 
         if (json.children != null) {
@@ -211,6 +212,18 @@ export class TabSetNode extends Node implements IDraggable, IDropTarget {
 
     isEnableTabScrollbar() {
         return this.getAttr("enableTabScrollbar") as boolean;
+    }
+
+    isPopupRoot() {
+        if (!(this.parent instanceof RowNode)) {
+            return false;
+        }
+
+        if (this.parent.getChildren().length !== 1) {
+            return false;
+        }
+
+        return !this.parent.getParent();
     }
 
     getClassNameTabStrip() {

--- a/src/view/Icons.tsx
+++ b/src/view/Icons.tsx
@@ -9,6 +9,22 @@ export const CloseIcon = () => {
     );
 }
 
+export const FloatingIcon = () => {
+    return (
+        <svg xmlns="http://www.w3.org/2000/svg" style={style} viewBox="0 0 24 24">
+            <path fill="transparent" stroke="var(--color-icon)" strokeDasharray="2,2" strokeWidth="2" d="M5 5h14v14H5z" paintOrder="markers stroke fill"/>
+        </svg>
+    )
+};
+
+export const DockableIcon = () => {
+    return (
+        <svg xmlns="http://www.w3.org/2000/svg" style={style} viewBox="0 0 24 24">
+            <path fill="transparent" stroke="var(--color-icon)" strokeWidth="2" d="M5 5h14v14H5z" paintOrder="markers stroke fill"/>
+        </svg>
+    );
+};
+
 export const MaximizeIcon = () => {
     return (
         <svg xmlns="http://www.w3.org/2000/svg" style={style} viewBox="0 0 24 24" fill="var(--color-icon)"><path d="M0 0h24v24H0z" fill="none" /><path stroke="var(--color-icon)" d="M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5v-5h-2v3zM14 5v2h3v3h2V5h-5z" /></svg>

--- a/src/view/Popup.tsx
+++ b/src/view/Popup.tsx
@@ -1,0 +1,38 @@
+import * as React from "react";
+import { LayoutInternal } from "./Layout";
+import { LayoutWindow } from "../model/LayoutWindow";
+import { LayoutPopup } from '../model/LayoutPopup';
+import { createPortal } from 'react-dom';
+import { CLASSES } from '../Types';
+import { Actions } from '../model/Actions';
+
+/** @internal */
+export interface IPopupWindowProps {
+    title: string;
+    layout: LayoutInternal;
+    layoutWindow: LayoutPopup;
+    url: string;
+    onCloseWindow: (layoutWindow: LayoutWindow) => void;
+    onSetWindow: (layoutWindow: LayoutWindow, window: Window) => void;
+}
+
+/** @internal */
+export const Popup = (props: React.PropsWithChildren<IPopupWindowProps>) => {
+    const { children, layout, layoutWindow } = props;
+    const { rect, windowId } = layoutWindow;
+    const { x, y, width, height } = rect;
+    const model = layout.getModel();
+    const zIndex = 9999 + model.getWindowOrderNumber(windowId);
+
+    const onPointerDown = () => {
+        layout.doAction({ type: Actions.BRING_TO_FRONT, data: { windowId } });
+    };
+
+    return (
+        createPortal(
+            <div className={CLASSES.FLEXLAYOUT__POPUP} style={{position: 'absolute', top: y, left: x, width, height, zIndex }} onPointerDown={onPointerDown}>
+                {children}
+            </div>,
+        document.body)
+    );
+};

--- a/src/view/Row.tsx
+++ b/src/view/Row.tsx
@@ -19,6 +19,7 @@ export const Row = (props: IRowProps) => {
     const selfRef = React.useRef<HTMLDivElement | null>(null);
 
     const horizontal = node.getOrientation() === Orientation.HORZ;
+    const renderPopupBar = layout.isPopup() && node.getChildren().length > 1;
 
     React.useLayoutEffect(() => {
         node.setRect(layout.getBoundingClientRect(selfRef.current!));
@@ -54,7 +55,7 @@ export const Row = (props: IRowProps) => {
         style.flexDirection = "column";
     }
 
-     return (
+     const row = (
         <div
             ref={selfRef}
             className={layout.getClassName(CLASSES.FLEXLAYOUT__ROW)}
@@ -63,6 +64,20 @@ export const Row = (props: IRowProps) => {
             {items}
         </div>
     );
+
+    if (renderPopupBar) {
+        return (
+            <div style={{display: 'flex', flexDirection: 'column', width: '100%', height: '100%'}}>
+                <div className={CLASSES.FLEXLAYOUT__POPUP_TABBAR_OUTER}
+                    onPointerDown={layout.onMoveStart} onPointerMove={layout.onMove} onPointerUp={layout.onMoveEnd}>
+                    <div className={CLASSES.FLEXLAYOUT__TABSET_TABBAR_INNER_TAB_CONTAINER}>Popup</div>
+                </div>
+                {row}
+            </div>
+        );
+    }
+
+    return row;
 };
 
 

--- a/src/view/TabButton.tsx
+++ b/src/view/TabButton.tsx
@@ -22,6 +22,7 @@ export const TabButton = (props: ITabButtonProps) => {
     const selfRef = React.useRef<HTMLDivElement | null>(null);
     const contentRef = React.useRef<HTMLInputElement | null>(null);
     const icons = layout.getIcons();
+    const isPopupMode = layout.isPopup() && node.isPopupRoot() && !layout.isDockingMode();
 
     React.useLayoutEffect(() => {
         node.setTabRect(layout.getBoundingClientRect(selfRef.current!));
@@ -31,6 +32,8 @@ export const TabButton = (props: ITabButtonProps) => {
     });
 
     const onDragStart = (event: React.DragEvent<HTMLElement>) => {
+        if (isPopupMode) return;
+
         if (node.isEnableDrag()) {
             event.stopPropagation(); // prevent starting a tabset drag as well
             layout.setDragNode(event.nativeEvent, node as TabNode);
@@ -40,6 +43,7 @@ export const TabButton = (props: ITabButtonProps) => {
     };
 
     const onDragEnd = (event: React.DragEvent<HTMLElement>) => {
+        if (isPopupMode) return;
         layout.clearDragMain();
     };
 
@@ -178,6 +182,13 @@ export const TabButton = (props: ITabButtonProps) => {
         );
     }
 
+    const movableEventsListeners: React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement> = {};
+    if (isPopupMode) {
+        movableEventsListeners.onPointerDown = layout.onMoveStart;
+        movableEventsListeners.onPointerMove = layout.onMove;
+        movableEventsListeners.onPointerUp = layout.onMoveEnd;
+    }
+
     return (
         <div
             ref={selfRef}
@@ -191,6 +202,7 @@ export const TabButton = (props: ITabButtonProps) => {
             onDragStart={onDragStart}
             onDragEnd={onDragEnd}
             onDoubleClick={onDoubleClick}
+            {...movableEventsListeners}
         >
             {leading}
             {content}

--- a/style/_base.scss
+++ b/style/_base.scss
@@ -167,6 +167,48 @@
             overflow: hidden;
         }
 
+        &__popup {
+            &_tabbar {
+                &_outer {
+                    box-sizing: border-box;
+                    background-color: var(--color-tabset-background);
+                    overflow: hidden;
+                    display: flex;
+                    font-size: var(--font-size);
+                }
+
+                &_outer_top {
+                    padding: 0px 2px 0px 2px;
+                    border-bottom: 1px solid var(--color-tabset-divider-line);
+                }
+
+                &_inner {
+                    position: relative;
+                    box-sizing: border-box;
+                    display: flex;
+                    flex-grow: 1;
+                    scrollbar-width: none;
+
+                    &::-webkit-scrollbar {
+                        display: none;
+                    }
+
+                    &_tab_container {
+                        position: relative;
+                        display: flex;
+                        padding-left: 4px;
+                        padding-right: 4px;
+                        box-sizing: border-box;
+                        white-space: nowrap;
+
+                        &_top {
+                            border-top: 2px solid transparent;
+                        }
+                    }
+                }
+            }
+        }
+
         &__tabset {
             display: flex;
             flex-direction: column;

--- a/style/combined.css
+++ b/style/combined.css
@@ -434,6 +434,38 @@
   box-sizing: border-box;
   overflow: hidden;
 }
+.flexlayout__popup_tabbar_outer {
+  box-sizing: border-box;
+  background-color: var(--color-tabset-background);
+  overflow: hidden;
+  display: flex;
+  font-size: var(--font-size);
+}
+.flexlayout__popup_tabbar_outer_top {
+  padding: 0px 2px 0px 2px;
+  border-bottom: 1px solid var(--color-tabset-divider-line);
+}
+.flexlayout__popup_tabbar_inner {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-grow: 1;
+  scrollbar-width: none;
+}
+.flexlayout__popup_tabbar_inner::-webkit-scrollbar {
+  display: none;
+}
+.flexlayout__popup_tabbar_inner_tab_container {
+  position: relative;
+  display: flex;
+  padding-left: 4px;
+  padding-right: 4px;
+  box-sizing: border-box;
+  white-space: nowrap;
+}
+.flexlayout__popup_tabbar_inner_tab_container_top {
+  border-top: 2px solid transparent;
+}
 .flexlayout__tabset {
   display: flex;
   flex-direction: column;

--- a/style/dark.css
+++ b/style/dark.css
@@ -203,6 +203,38 @@
   box-sizing: border-box;
   overflow: hidden;
 }
+.flexlayout__popup_tabbar_outer {
+  box-sizing: border-box;
+  background-color: var(--color-tabset-background);
+  overflow: hidden;
+  display: flex;
+  font-size: var(--font-size);
+}
+.flexlayout__popup_tabbar_outer_top {
+  padding: 0px 2px 0px 2px;
+  border-bottom: 1px solid var(--color-tabset-divider-line);
+}
+.flexlayout__popup_tabbar_inner {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-grow: 1;
+  scrollbar-width: none;
+}
+.flexlayout__popup_tabbar_inner::-webkit-scrollbar {
+  display: none;
+}
+.flexlayout__popup_tabbar_inner_tab_container {
+  position: relative;
+  display: flex;
+  padding-left: 4px;
+  padding-right: 4px;
+  box-sizing: border-box;
+  white-space: nowrap;
+}
+.flexlayout__popup_tabbar_inner_tab_container_top {
+  border-top: 2px solid transparent;
+}
 .flexlayout__tabset {
   display: flex;
   flex-direction: column;

--- a/style/gray.css
+++ b/style/gray.css
@@ -203,6 +203,38 @@
   box-sizing: border-box;
   overflow: hidden;
 }
+.flexlayout__popup_tabbar_outer {
+  box-sizing: border-box;
+  background-color: var(--color-tabset-background);
+  overflow: hidden;
+  display: flex;
+  font-size: var(--font-size);
+}
+.flexlayout__popup_tabbar_outer_top {
+  padding: 0px 2px 0px 2px;
+  border-bottom: 1px solid var(--color-tabset-divider-line);
+}
+.flexlayout__popup_tabbar_inner {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-grow: 1;
+  scrollbar-width: none;
+}
+.flexlayout__popup_tabbar_inner::-webkit-scrollbar {
+  display: none;
+}
+.flexlayout__popup_tabbar_inner_tab_container {
+  position: relative;
+  display: flex;
+  padding-left: 4px;
+  padding-right: 4px;
+  box-sizing: border-box;
+  white-space: nowrap;
+}
+.flexlayout__popup_tabbar_inner_tab_container_top {
+  border-top: 2px solid transparent;
+}
 .flexlayout__tabset {
   display: flex;
   flex-direction: column;

--- a/style/light.css
+++ b/style/light.css
@@ -203,6 +203,38 @@
   box-sizing: border-box;
   overflow: hidden;
 }
+.flexlayout__popup_tabbar_outer {
+  box-sizing: border-box;
+  background-color: var(--color-tabset-background);
+  overflow: hidden;
+  display: flex;
+  font-size: var(--font-size);
+}
+.flexlayout__popup_tabbar_outer_top {
+  padding: 0px 2px 0px 2px;
+  border-bottom: 1px solid var(--color-tabset-divider-line);
+}
+.flexlayout__popup_tabbar_inner {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-grow: 1;
+  scrollbar-width: none;
+}
+.flexlayout__popup_tabbar_inner::-webkit-scrollbar {
+  display: none;
+}
+.flexlayout__popup_tabbar_inner_tab_container {
+  position: relative;
+  display: flex;
+  padding-left: 4px;
+  padding-right: 4px;
+  box-sizing: border-box;
+  white-space: nowrap;
+}
+.flexlayout__popup_tabbar_inner_tab_container_top {
+  border-top: 2px solid transparent;
+}
 .flexlayout__tabset {
   display: flex;
   flex-direction: column;

--- a/style/rounded.css
+++ b/style/rounded.css
@@ -203,6 +203,38 @@
   box-sizing: border-box;
   overflow: hidden;
 }
+.flexlayout__popup_tabbar_outer {
+  box-sizing: border-box;
+  background-color: var(--color-tabset-background);
+  overflow: hidden;
+  display: flex;
+  font-size: var(--font-size);
+}
+.flexlayout__popup_tabbar_outer_top {
+  padding: 0px 2px 0px 2px;
+  border-bottom: 1px solid var(--color-tabset-divider-line);
+}
+.flexlayout__popup_tabbar_inner {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-grow: 1;
+  scrollbar-width: none;
+}
+.flexlayout__popup_tabbar_inner::-webkit-scrollbar {
+  display: none;
+}
+.flexlayout__popup_tabbar_inner_tab_container {
+  position: relative;
+  display: flex;
+  padding-left: 4px;
+  padding-right: 4px;
+  box-sizing: border-box;
+  white-space: nowrap;
+}
+.flexlayout__popup_tabbar_inner_tab_container_top {
+  border-top: 2px solid transparent;
+}
 .flexlayout__tabset {
   display: flex;
   flex-direction: column;

--- a/style/underline.css
+++ b/style/underline.css
@@ -206,6 +206,38 @@
   box-sizing: border-box;
   overflow: hidden;
 }
+.flexlayout__popup_tabbar_outer {
+  box-sizing: border-box;
+  background-color: var(--color-tabset-background);
+  overflow: hidden;
+  display: flex;
+  font-size: var(--font-size);
+}
+.flexlayout__popup_tabbar_outer_top {
+  padding: 0px 2px 0px 2px;
+  border-bottom: 1px solid var(--color-tabset-divider-line);
+}
+.flexlayout__popup_tabbar_inner {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-grow: 1;
+  scrollbar-width: none;
+}
+.flexlayout__popup_tabbar_inner::-webkit-scrollbar {
+  display: none;
+}
+.flexlayout__popup_tabbar_inner_tab_container {
+  position: relative;
+  display: flex;
+  padding-left: 4px;
+  padding-right: 4px;
+  box-sizing: border-box;
+  white-space: nowrap;
+}
+.flexlayout__popup_tabbar_inner_tab_container_top {
+  border-top: 2px solid transparent;
+}
 .flexlayout__tabset {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
### Summary
This draft PR introduces **popup support** to `flex-layout`.  
A popup is a draggable and resizable **div inside the page**, not a browser window.  

A **"Toggle docking"** button has been added to the popup tab bar:
- **Floating mode** → the popup behaves as a movable/resizable window  
- **Dockable mode** → the popup can be dragged and docked into a fixed position within the layout  

### Current state
- Basic implementation of popup creation, dragging and resizing  
- Toggle between floating and dockable modes is functional  
- UI integration works but still needs refinement  

### Open questions / feedback requested
- Does the overall **direction** of this feature align with project goals?  
- Is the **API/UX** for toggling between floating/dockable modes acceptable?  
- Would maintainers be open to merging this feature once improved?  

This PR is **not ready to merge yet** – the goal is to gather early feedback and validate whether this feature is a good fit for `flex-layout`. 

https://github.com/user-attachments/assets/948dd85f-24f0-41b0-9f02-7f9fd0241240

