### PR TITLE
fix: use flex-start instead of start for align-items

### DIFF
--- a/style/_base.scss
+++ b/style/_base.scss
@@ -35,7 +35,7 @@
                 z-index: 100;
                 display: flex;
                 flex-direction: column;
-                align-items: start;
+                align-items: flex-start;
             }
 
             &_moveables {

--- a/style/combined.css
+++ b/style/combined.css
@@ -313,7 +313,7 @@
   z-index: 100;
   display: flex;
   flex-direction: column;
-  align-items: start;
+  align-items: flex-start;
 }
 .flexlayout__layout_moveables {
   visibility: hidden;

--- a/style/dark.css
+++ b/style/dark.css
@@ -82,7 +82,7 @@
   z-index: 100;
   display: flex;
   flex-direction: column;
-  align-items: start;
+  align-items: flex-start;
 }
 .flexlayout__layout_moveables {
   visibility: hidden;

--- a/style/gray.css
+++ b/style/gray.css
@@ -82,7 +82,7 @@
   z-index: 100;
   display: flex;
   flex-direction: column;
-  align-items: start;
+  align-items: flex-start;
 }
 .flexlayout__layout_moveables {
   visibility: hidden;

--- a/style/light.css
+++ b/style/light.css
@@ -82,7 +82,7 @@
   z-index: 100;
   display: flex;
   flex-direction: column;
-  align-items: start;
+  align-items: flex-start;
 }
 .flexlayout__layout_moveables {
   visibility: hidden;

--- a/style/rounded.css
+++ b/style/rounded.css
@@ -82,7 +82,7 @@
   z-index: 100;
   display: flex;
   flex-direction: column;
-  align-items: start;
+  align-items: flex-start;
 }
 .flexlayout__layout_moveables {
   visibility: hidden;

--- a/style/underline.css
+++ b/style/underline.css
@@ -85,7 +85,7 @@
   z-index: 100;
   display: flex;
   flex-direction: column;
-  align-items: start;
+  align-items: flex-start;
 }
 .flexlayout__layout_moveables {
   visibility: hidden;


### PR DESCRIPTION
## Summary

The `align-items: start` declaration in `_base.scss` has mixed browser support in flexbox contexts, causing autoprefixer to emit a warning during builds:

```
(84:3) autoprefixer: start value has mixed support, consider using flex-start instead
```

This changes `align-items: start` to `align-items: flex-start` in the source SCSS and recompiles the theme CSS files. `flex-start` is the canonical flexbox value with universal browser support.