### PR TITLE
fix ResizeObserver not working in a popout

### DIFF
--- a/src/view/Layout.tsx
+++ b/src/view/Layout.tsx
@@ -263,8 +263,11 @@ export class LayoutInternal extends React.Component<ILayoutInternalProps, ILayou
         this.layoutWindow.window = this.currentWindow;
         this.layoutWindow.toScreenRectFunction = (r) => this.getScreenRect(r);
 
-        this.resizeObserver = new ResizeObserver(entries => {
-            requestAnimationFrame(() => {
+        // Spec says ResizeObserver triggers callback in the same window as the observed element,
+        // but it's just not true in Chrome, so, use ResizeObserver from PARENT window
+        const parentWindow = (this.currentDocument.defaultView ?? window);
+        this.resizeObserver = new parentWindow.ResizeObserver(entries => {
+            parentWindow.requestAnimationFrame(() => {
                 this.updateRect();
             });
         });
@@ -279,7 +282,7 @@ export class LayoutInternal extends React.Component<ILayoutInternalProps, ILayou
             this.currentWindow.addEventListener("resize", () => {
                 this.updateRect();
             });
-
+            this.resizeObserver.observe(this.currentWindow.document.documentElement);
             const sourceElement = this.props.mainLayout!.getRootDiv()!;
             const targetElement = this.selfRef.current!;
 


### PR DESCRIPTION
I noticed that when window is opened in a popout, and the main window is unfocused, layout recalculations doesn't happen (or they heavily throttled with up to 1 minute delay).

A fix to that would be to use ResizeObserver of current window (just creating `new ResizeObserver(...)` uses one from parent window and executes callbacks in main window context for some reason).

Also, window resize event is throttled too, so, I've added observation on document body of popout as a fallback.

Not a final and clean solution, I guess, but somehow it works on my setup in a complex app with nested Layouts.